### PR TITLE
Fix payer index when deleting a person

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,9 @@
         people.splice(index, 1);
         transactions.forEach((t) => {
           t.splits.splice(index, 1);
-          if (t.payer >= people.length) t.payer = 0;
+          if (t.payer > index) {
+            t.payer--;
+          }
         });
         renderPeople();
         renderTransactionTable();


### PR DESCRIPTION
## Summary
- Correct payer adjustment after deleting a person so transactions retain proper payers

## Testing
- `npx prettier --check index.html`

------
https://chatgpt.com/codex/tasks/task_e_68a2c04d560483209d4d016b8222e440