### PR TITLE
Fix JSON state save/load and add tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,12 +126,17 @@
     <div id="summary"></div>
 
     <h2>5. Save/Load State</h2>
-    <div style="display: flex; align-items: center; gap: 5px; margin: 5px 0;">
+    <div style="display: flex; align-items: center; gap: 5px; margin: 5px 0">
       <input
         id="state-json-display"
         type="text"
         readonly
-        style="flex: 1; white-space: nowrap; overflow-x: auto; background-color: #f0f0f0;"
+        style="
+          flex: 1;
+          white-space: nowrap;
+          overflow-x: auto;
+          background-color: #f0f0f0;
+        "
         placeholder="Current state JSON"
       />
       <button onclick="downloadJson()">Export JSON File</button>
@@ -144,6 +149,16 @@
     ></textarea>
     <br />
     <button onclick="loadStateFromJson()">Load from JSON</button>
+    <button onclick="document.getElementById('state-json-file').click()">
+      Load from JSON File
+    </button>
+    <input
+      type="file"
+      id="state-json-file"
+      accept="application/json"
+      style="display: none"
+      onchange="loadStateFromJsonFile(this.files[0])"
+    />
 
     <script src="scripts.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- align JSON validation with current transaction structure
- make JSON load more robust and export helpers
- add tests for saving and loading state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2d6855fb8832085cf0188404246ba