### PR TITLE
Refactor site scripts into ES modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
     <h2>1. People</h2>
     <div id="people-section">
       <input type="text" id="person-name" placeholder="Name" />
-      <button id="save-people" onclick="addPerson()">Add Person</button>
+      <button id="save-people">Add Person</button>
       <ul id="people-list"></ul>
     </div>
 
@@ -121,7 +121,7 @@
         "
         placeholder="Current state JSON"
       />
-      <button onclick="downloadJson()">Download JSON File</button>
+      <button id="download-json">Download JSON File</button>
     </div>
     <textarea
       id="state-json-input"
@@ -130,16 +130,13 @@
       placeholder="State JSON"
     ></textarea>
     <br />
-    <button onclick="loadStateFromJson()">Load from JSON</button>
-    <button onclick="document.getElementById('state-json-file').click()">
-      Load from JSON File
-    </button>
+    <button id="load-json">Load from JSON</button>
+    <button id="load-json-file">Load from JSON File</button>
     <input
       type="file"
       id="state-json-file"
       accept="application/json"
       style="display: none"
-      onchange="loadStateFromJsonFile(this.files[0])"
     />
 
     <h2>6. Share</h2>
@@ -159,6 +156,6 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.5.0/lz-string.min.js"></script>
-    <script src="scripts.js"></script>
+    <script type="module" src="main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,30 @@
+import { addPerson } from "./render.js";
+import {
+  loadStateFromJson,
+  loadStateFromJsonFile,
+  loadStateFromUrl,
+  downloadJson,
+} from "./share.js";
+
+export * from "./state.js";
+export * from "./render.js";
+export * from "./share.js";
+
+document.getElementById("save-people")?.addEventListener("click", addPerson);
+document
+  .getElementById("load-json")
+  ?.addEventListener("click", loadStateFromJson);
+document
+  .getElementById("load-json-file")
+  ?.addEventListener("click", () =>
+    document.getElementById("state-json-file")?.click(),
+  );
+document.getElementById("state-json-file")?.addEventListener("change", (e) => {
+  const file = e.target.files[0];
+  if (file) loadStateFromJsonFile(file);
+});
+document
+  .getElementById("download-json")
+  ?.addEventListener("click", downloadJson);
+
+loadStateFromUrl();

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "cost-splits.github.io",
   "version": "1.0.0",
   "description": "",
-  "main": "scripts.js",
+  "main": "main.js",
   "scripts": {
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "lint": "eslint ."
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "prettier": {
     "printWidth": 80,
     "proseWrap": "always"

--- a/render.js
+++ b/render.js
@@ -1,108 +1,20 @@
-/**
- * Compute the amounts paid, owed and net balance for each person.
- *
- * @param {string[]} people - List of participant names.
- * @param {Array<{payer:number,cost:number,splits:number[],items?:Array<{item?:string,cost:number,splits:number[]}>}>} transactions -
- *   Transactions describing who paid and how the cost is split, optionally
- *   containing itemized sub-splits.
- * @returns {{paid:number[], owes:number[], nets:number[]}} Summary arrays for
- *   each person.
- */
-function computeSummary(people, transactions) {
-  const paid = Array(people.length).fill(0);
-  const owes = Array(people.length).fill(0);
-
-  transactions.forEach((t) => {
-    paid[t.payer] += t.cost;
-    if (Array.isArray(t.items) && t.items.length > 0) {
-      const itemsTotal = t.items.reduce((sum, it) => sum + it.cost, 0);
-      if (itemsTotal > 0) {
-        const scale = t.cost / itemsTotal;
-        const personTotals = Array(people.length).fill(0);
-        t.items.forEach((it) => {
-          const effCost = it.cost * scale;
-          const splitSum = it.splits.reduce((a, b) => a + b, 0);
-          if (splitSum > 0) {
-            it.splits.forEach((s, i) => {
-              personTotals[i] += (s / splitSum) * effCost;
-            });
-          }
-        });
-        personTotals.forEach((amt, i) => {
-          owes[i] += amt;
-        });
-      }
-    } else {
-      const totalSplit = t.splits.reduce((a, b) => a + b, 0);
-      if (totalSplit > 0) {
-        t.splits.forEach((s, i) => {
-          owes[i] += (s / totalSplit) * t.cost;
-        });
-      }
-    }
-  });
-
-  const nets = people.map((_, i) => paid[i] - owes[i]);
-  return { paid, owes, nets };
-}
-/** @type {string[]} */
-const people = [];
-/**
- * @type {Array<{
- *   name?: string,
- *   cost: number,
- *   payer: number,
- *   splits: number[],
- *   items?: Array<{ item?: string, cost: number, splits: number[] }>
- * }>}
- */
-const transactions = [];
-/** @type {Set<number>} */
-const collapsedSplit = new Set();
-/** @type {Set<number>} */
-const collapsedDetails = new Set();
-/* global LZString */
-const lz = typeof LZString !== "undefined" ? LZString : require("lz-string");
-
-/**
- * Handle updates after state changes by refreshing derived values.
- */
-function afterChange() {
-  updateCurrentStateJson();
-  updateShareableUrl();
-  calculateSummary();
-}
-
-/**
- * Check whether a value represents a valid dollar amount.
- *
- * @param {string} value - Input string to validate.
- * @param {boolean} [allowEmpty=false] - Whether an empty string is allowed.
- * @returns {boolean} True if the value is a valid dollar amount.
- */
-function isValidDollar(value, allowEmpty = false) {
-  if (allowEmpty && value.trim() === "") return true;
-  return /^\d+(\.\d{0,2})?$/.test(value);
-}
-
-/**
- * Validate an arbitrary number allowing any number of decimals.
- *
- * @param {string} value - Input string to validate.
- * @param {boolean} [allowEmpty=false] - Whether an empty string is allowed.
- * @returns {boolean} True if the value is numeric.
- */
-function isValidNumber(value, allowEmpty = false) {
-  if (allowEmpty && value.trim() === "") return true;
-  return /^\d+(\.\d+)?$/.test(value);
-}
+import {
+  people,
+  transactions,
+  collapsedSplit,
+  collapsedDetails,
+  isValidDollar,
+  isValidNumber,
+  computeSummary,
+} from "./state.js";
+import { afterChange } from "./share.js";
 
 // ---- PEOPLE ----
 
 /**
  * Add a new person from the name input field.
  */
-function addPerson() {
+export function addPerson() {
   const input = document.getElementById("person-name");
   const name = input.value.trim();
   if (!name || people.includes(name)) {
@@ -129,7 +41,7 @@ function addPerson() {
  *
  * @param {number} index - Index of the person to remove.
  */
-function deletePerson(index) {
+export function deletePerson(index) {
   const involved = transactions.some(
     (t) =>
       t.payer === index ||
@@ -173,7 +85,7 @@ function deletePerson(index) {
 /**
  * Render the list of people with delete controls.
  */
-function renderPeople() {
+export function renderPeople() {
   const list = document.getElementById("people-list");
   list.innerHTML = "";
   people.forEach((p, i) => {
@@ -193,7 +105,7 @@ function renderPeople() {
 /**
  * Render the transactions table allowing editing and deletion.
  */
-function renderTransactionTable() {
+export function renderTransactionTable() {
   const table = document.getElementById("transaction-table");
   table.innerHTML = "";
   if (people.length === 0) {
@@ -256,7 +168,7 @@ function renderTransactionTable() {
 /**
  * Add a new transaction using values from the input fields.
  */
-function addTransaction() {
+export function addTransaction() {
   const nameInput = document.getElementById("new-t-name");
   const costInput = document.getElementById("new-t-cost");
   const payer = parseInt(document.getElementById("new-t-payer").value);
@@ -289,7 +201,7 @@ function addTransaction() {
  * @param {string} value - New value from the input element.
  * @param {HTMLInputElement|HTMLSelectElement} el - Element being edited.
  */
-function editTransaction(i, field, value, el) {
+export function editTransaction(i, field, value, el) {
   if (field === "cost") {
     if (!isValidDollar(value)) {
       el.classList.add("invalid-cell");
@@ -312,7 +224,7 @@ function editTransaction(i, field, value, el) {
  *
  * @param {number} i - Index of transaction to delete.
  */
-function deleteTransaction(i) {
+export function deleteTransaction(i) {
   transactions.splice(i, 1);
   renderTransactionTable();
   renderSplitTable();
@@ -324,7 +236,7 @@ function deleteTransaction(i) {
 /**
  * Render the table showing split inputs for each transaction.
  */
-function renderSplitTable() {
+export function renderSplitTable() {
   const splitDiv = document.getElementById("split-table");
   splitDiv.innerHTML = "";
   if (transactions.length === 0 || people.length === 0) return;
@@ -386,7 +298,7 @@ function renderSplitTable() {
  * @param {string} value - New value from the input element.
  * @param {HTMLInputElement} el - The input element being edited.
  */
-function editSplit(ti, pi, value, el) {
+export function editSplit(ti, pi, value, el) {
   if (!isValidNumber(value, true)) {
     el.classList.add("invalid-cell");
     return;
@@ -403,7 +315,7 @@ function editSplit(ti, pi, value, el) {
  *
  * @param {number} ti - Transaction index.
  */
-function itemizeTransaction(ti) {
+export function itemizeTransaction(ti) {
   transactions[ti].items = [];
   collapsedSplit.delete(ti);
   collapsedDetails.delete(ti);
@@ -416,7 +328,7 @@ function itemizeTransaction(ti) {
  *
  * @param {number} ti - Transaction index.
  */
-function unitemizeTransaction(ti) {
+export function unitemizeTransaction(ti) {
   delete transactions[ti].items;
   collapsedSplit.delete(ti);
   collapsedDetails.delete(ti);
@@ -429,7 +341,7 @@ function unitemizeTransaction(ti) {
  *
  * @param {number} ti - Transaction index.
  */
-function addItem(ti) {
+export function addItem(ti) {
   const item = { item: "", cost: 0, splits: Array(people.length).fill(0) };
   transactions[ti].items.push(item);
   renderSplitTable();
@@ -442,7 +354,7 @@ function addItem(ti) {
  * @param {number} ti - Transaction index.
  * @param {number} ii - Item index.
  */
-function deleteItem(ti, ii) {
+export function deleteItem(ti, ii) {
   transactions[ti].items.splice(ii, 1);
   if (transactions[ti].items.length === 0) {
     unitemizeTransaction(ti);
@@ -461,7 +373,7 @@ function deleteItem(ti, ii) {
  * @param {string} value - New value from the input.
  * @param {HTMLInputElement} [el] - Element being edited.
  */
-function editItem(ti, ii, field, value, el) {
+export function editItem(ti, ii, field, value, el) {
   const item = transactions[ti].items[ii];
   if (field === "cost") {
     if (!isValidDollar(value)) {
@@ -486,7 +398,7 @@ function editItem(ti, ii, field, value, el) {
  * @param {string} value - New value from the input element.
  * @param {HTMLInputElement} el - Element being edited.
  */
-function editItemSplit(ti, ii, pi, value, el) {
+export function editItemSplit(ti, ii, pi, value, el) {
   if (!isValidNumber(value, true)) {
     el.classList.add("invalid-cell");
     return;
@@ -503,7 +415,7 @@ function editItemSplit(ti, ii, pi, value, el) {
  *
  * @param {number} ti - Transaction index.
  */
-function toggleSplitItems(ti) {
+export function toggleSplitItems(ti) {
   if (collapsedSplit.has(ti)) collapsedSplit.delete(ti);
   else collapsedSplit.add(ti);
   renderSplitTable();
@@ -514,7 +426,7 @@ function toggleSplitItems(ti) {
  *
  * @param {number} ti - Transaction index.
  */
-function toggleDetailItems(ti) {
+export function toggleDetailItems(ti) {
   if (collapsedDetails.has(ti)) collapsedDetails.delete(ti);
   else collapsedDetails.add(ti);
   renderSplitDetails();
@@ -524,7 +436,7 @@ function toggleDetailItems(ti) {
 /**
  * Render detailed amounts owed for each transaction and person.
  */
-function renderSplitDetails() {
+export function renderSplitDetails() {
   const div = document.getElementById("split-details");
   div.innerHTML = "";
   if (transactions.length === 0 || people.length === 0) return;
@@ -608,7 +520,7 @@ function renderSplitDetails() {
 /**
  * Render a summary table of totals paid, owed and net for each person.
  */
-function calculateSummary() {
+export function calculateSummary() {
   const summaryEl = document.getElementById("summary");
   if (!summaryEl) return;
   const { paid, owes, nets } = computeSummary(people, transactions);
@@ -648,255 +560,4 @@ function calculateSummary() {
   html += "</table>";
 
   summaryEl.innerHTML = html;
-}
-/**
- * Clear all people and transactions from the current state.
- */
-function resetState() {
-  people.length = 0;
-  transactions.length = 0;
-  collapsedSplit.clear();
-  collapsedDetails.clear();
-  afterChange();
-}
-
-// ---- SAVE/LOAD STATE ----
-// Validate the structure and types of the loaded state
-/**
- * Ensure a loaded state object has the expected structure.
- *
- * @param {object} state - State object to validate.
- * @throws {Error} If the state is malformed.
- */
-function validateState(state) {
-  if (
-    typeof state !== "object" ||
-    state === null ||
-    !Array.isArray(state.people) ||
-    !Array.isArray(state.transactions)
-  ) {
-    throw new Error("Invalid state: missing people or transactions arrays");
-  }
-
-  // Validate people: array of non-empty strings
-  if (
-    !state.people.every((p) => typeof p === "string" && p.trim().length > 0)
-  ) {
-    throw new Error("Invalid state: people must be non-empty strings");
-  }
-
-  // Validate transactions: array of objects with expected fields
-  const transactionsValid = state.transactions.every((t) => {
-    const baseValid =
-      t &&
-      typeof t === "object" &&
-      (typeof t.name === "undefined" || typeof t.name === "string") &&
-      typeof t.payer === "number" &&
-      Number.isInteger(t.payer) &&
-      typeof t.cost === "number" &&
-      isFinite(t.cost) &&
-      Array.isArray(t.splits) &&
-      t.splits.length === state.people.length &&
-      t.splits.every((s) => typeof s === "number" && isFinite(s));
-    if (!baseValid) return false;
-    if (typeof t.items === "undefined") return true;
-    if (!Array.isArray(t.items)) return false;
-    return t.items.every(
-      (it) =>
-        it &&
-        typeof it === "object" &&
-        (typeof it.item === "undefined" || typeof it.item === "string") &&
-        typeof it.cost === "number" &&
-        isFinite(it.cost) &&
-        Array.isArray(it.splits) &&
-        it.splits.length === state.people.length &&
-        it.splits.every((s) => typeof s === "number" && isFinite(s)),
-    );
-  });
-
-  if (!transactionsValid) {
-    throw new Error("Invalid state: transactions malformed");
-  }
-}
-
-/**
- * Write the current state to the display input as JSON.
- */
-function updateCurrentStateJson() {
-  const display = document.getElementById("state-json-display");
-  const state = { people, transactions };
-  if (display) display.value = JSON.stringify(state);
-}
-
-/**
- * Update the share URL field with a link to the current state.
- * Uses the current page URL (including file:// URLs) as the base.
- * The state JSON is compressed with LZString to shorten the URL.
- */
-function updateShareableUrl() {
-  const display = document.getElementById("share-url-display");
-  if (!display || typeof window === "undefined") return;
-  const base = window.location.href.split(/[?#]/)[0];
-  const json = JSON.stringify({ people, transactions });
-  const compressed = lz.compressToEncodedURIComponent(json);
-  display.value = `${base}?state=${compressed}`;
-}
-
-/**
- * Replace the current state with a loaded state and refresh the UI.
- *
- * @param {object} state - Parsed state object.
- */
-function applyLoadedState(state) {
-  validateState(state);
-  people.length = 0;
-  transactions.length = 0;
-  collapsedSplit.clear();
-  collapsedDetails.clear();
-  state.people.forEach((p) => people.push(p));
-  state.transactions.forEach((t) => transactions.push(t));
-
-  if (
-    typeof renderPeople === "function" &&
-    document.getElementById("people-list")
-  ) {
-    renderPeople();
-  }
-  if (
-    typeof renderTransactionTable === "function" &&
-    document.getElementById("transaction-table")
-  ) {
-    renderTransactionTable();
-  }
-  if (
-    typeof renderSplitTable === "function" &&
-    document.getElementById("split-table")
-  ) {
-    renderSplitTable();
-  }
-
-  const summaryEl = document.getElementById("summary");
-  if (summaryEl) summaryEl.innerHTML = "";
-
-  afterChange();
-}
-
-/**
- * Load state from the JSON text area.
- */
-function loadStateFromJson() {
-  const textarea = document.getElementById("state-json-input");
-  try {
-    const state = JSON.parse(textarea.value);
-    applyLoadedState(state);
-  } catch (e) {
-    if (typeof alert === "function") {
-      alert("Failed to load state: " + (e && e.message ? e.message : e));
-    }
-  }
-}
-
-/**
- * Load state from a JSON file chosen by the user.
- *
- * @param {File} file - JSON file to read.
- */
-async function loadStateFromJsonFile(file) {
-  try {
-    const text = await new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result);
-      reader.onerror = () => reject(reader.error);
-      reader.readAsText(file);
-    });
-    const textarea = document.getElementById("state-json-input");
-    if (textarea) textarea.value = text;
-    const state = JSON.parse(text);
-    applyLoadedState(state);
-  } catch (e) {
-    if (typeof alert === "function") {
-      alert("Failed to load state: " + (e && e.message ? e.message : e));
-    }
-  }
-}
-
-/**
- * Load state from the `state` query parameter if present.
- * The state is assumed to be compressed with LZString.
- */
-function loadStateFromUrl() {
-  try {
-    const params = new URLSearchParams(window.location.search);
-    const value = params.get("state");
-    if (!value) return;
-    const json = lz.decompressFromEncodedURIComponent(value);
-    if (!json) throw new Error("Failed to decode state");
-    const state = JSON.parse(json);
-    applyLoadedState(state);
-  } catch (e) {
-    if (typeof alert === "function") {
-      alert("Failed to load state: " + (e && e.message ? e.message : e));
-    }
-  }
-}
-
-/**
- * Trigger a download of the current state as a JSON file.
- */
-function downloadJson() {
-  const state = { people, transactions };
-  const dataStr = JSON.stringify(state);
-  const blob = new Blob([dataStr], { type: "application/json" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = "cost-splits.json";
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
-}
-if (typeof module !== "undefined" && module.exports) {
-  module.exports = {
-    computeSummary,
-    resetState,
-    addPerson,
-    updateCurrentStateJson,
-    updateShareableUrl,
-    loadStateFromJson,
-    loadStateFromJsonFile,
-    loadStateFromUrl,
-    _people: people,
-    _transactions: transactions,
-    downloadJson,
-  };
-}
-if (typeof window !== "undefined") {
-  window.computeSummary = computeSummary;
-  window.addPerson = addPerson;
-  window.deletePerson = deletePerson;
-  window.renderPeople = renderPeople;
-  window.renderTransactionTable = renderTransactionTable;
-  window.addTransaction = addTransaction;
-  window.editTransaction = editTransaction;
-  window.deleteTransaction = deleteTransaction;
-  window.renderSplitTable = renderSplitTable;
-  window.editSplit = editSplit;
-  window.itemizeTransaction = itemizeTransaction;
-  window.unitemizeTransaction = unitemizeTransaction;
-  window.addItem = addItem;
-  window.deleteItem = deleteItem;
-  window.editItem = editItem;
-  window.editItemSplit = editItemSplit;
-  window.toggleSplitItems = toggleSplitItems;
-  window.toggleDetailItems = toggleDetailItems;
-  window.renderSplitDetails = renderSplitDetails;
-  window.calculateSummary = calculateSummary;
-  window.updateCurrentStateJson = updateCurrentStateJson;
-  window.loadStateFromJson = loadStateFromJson;
-  window.loadStateFromJsonFile = loadStateFromJsonFile;
-  window.downloadJson = downloadJson;
-  window.updateShareableUrl = updateShareableUrl;
-  window.loadStateFromUrl = loadStateFromUrl;
-  loadStateFromUrl();
 }

--- a/share.js
+++ b/share.js
@@ -1,0 +1,237 @@
+/* global LZString */
+import {
+  people,
+  transactions,
+  collapsedSplit,
+  collapsedDetails,
+} from "./state.js";
+import {
+  renderPeople,
+  renderTransactionTable,
+  renderSplitTable,
+  calculateSummary,
+} from "./render.js";
+
+let lz;
+if (typeof LZString !== "undefined") {
+  lz = LZString;
+} else {
+  const mod = await import("lz-string");
+  lz = mod.default;
+}
+
+/**
+ * Write the current state to the display input as JSON.
+ */
+export function updateCurrentStateJson() {
+  const display = document.getElementById("state-json-display");
+  const state = { people, transactions };
+  if (display) display.value = JSON.stringify(state);
+}
+
+/**
+ * Update the share URL field with a link to the current state.
+ * Uses the current page URL (including file:// URLs) as the base.
+ * The state JSON is compressed with LZString to shorten the URL.
+ */
+export function updateShareableUrl() {
+  const display = document.getElementById("share-url-display");
+  if (!display || typeof window === "undefined") return;
+  const base = window.location.href.split(/[?#]/)[0];
+  const json = JSON.stringify({ people, transactions });
+  const compressed = lz.compressToEncodedURIComponent(json);
+  display.value = `${base}?state=${compressed}`;
+}
+
+// Validate the structure and types of the loaded state
+/**
+ * Ensure a loaded state object has the expected structure.
+ *
+ * @param {object} state - State object to validate.
+ * @throws {Error} If the state is malformed.
+ */
+export function validateState(state) {
+  if (
+    typeof state !== "object" ||
+    state === null ||
+    !Array.isArray(state.people) ||
+    !Array.isArray(state.transactions)
+  ) {
+    throw new Error("Invalid state: missing people or transactions arrays");
+  }
+
+  // Validate people: array of non-empty strings
+  if (
+    !state.people.every((p) => typeof p === "string" && p.trim().length > 0)
+  ) {
+    throw new Error("Invalid state: people must be non-empty strings");
+  }
+
+  // Validate transactions: array of objects with expected fields
+  const transactionsValid = state.transactions.every((t) => {
+    const baseValid =
+      t &&
+      typeof t === "object" &&
+      (typeof t.name === "undefined" || typeof t.name === "string") &&
+      typeof t.payer === "number" &&
+      Number.isInteger(t.payer) &&
+      typeof t.cost === "number" &&
+      isFinite(t.cost) &&
+      Array.isArray(t.splits) &&
+      t.splits.length === state.people.length &&
+      t.splits.every((s) => typeof s === "number" && isFinite(s));
+    if (!baseValid) return false;
+    if (typeof t.items === "undefined") return true;
+    if (!Array.isArray(t.items)) return false;
+    return t.items.every(
+      (it) =>
+        it &&
+        typeof it === "object" &&
+        (typeof it.item === "undefined" || typeof it.item === "string") &&
+        typeof it.cost === "number" &&
+        isFinite(it.cost) &&
+        Array.isArray(it.splits) &&
+        it.splits.length === state.people.length &&
+        it.splits.every((s) => typeof s === "number" && isFinite(s)),
+    );
+  });
+
+  if (!transactionsValid) {
+    throw new Error("Invalid state: transactions malformed");
+  }
+}
+
+/**
+ * Replace the current state with a loaded state and refresh the UI.
+ *
+ * @param {object} state - Parsed state object.
+ */
+export function applyLoadedState(state) {
+  validateState(state);
+  people.length = 0;
+  transactions.length = 0;
+  collapsedSplit.clear();
+  collapsedDetails.clear();
+  state.people.forEach((p) => people.push(p));
+  state.transactions.forEach((t) => transactions.push(t));
+
+  if (
+    typeof renderPeople === "function" &&
+    document.getElementById("people-list")
+  ) {
+    renderPeople();
+  }
+  if (
+    typeof renderTransactionTable === "function" &&
+    document.getElementById("transaction-table")
+  ) {
+    renderTransactionTable();
+  }
+  if (
+    typeof renderSplitTable === "function" &&
+    document.getElementById("split-table")
+  ) {
+    renderSplitTable();
+  }
+
+  const summaryEl = document.getElementById("summary");
+  if (summaryEl) summaryEl.innerHTML = "";
+
+  afterChange();
+}
+
+/**
+ * Load state from the JSON text area.
+ */
+export function loadStateFromJson() {
+  const textarea = document.getElementById("state-json-input");
+  try {
+    const state = JSON.parse(textarea.value);
+    applyLoadedState(state);
+  } catch (e) {
+    if (typeof alert === "function") {
+      alert("Failed to load state: " + (e && e.message ? e.message : e));
+    }
+  }
+}
+
+/**
+ * Load state from a JSON file chosen by the user.
+ *
+ * @param {File} file - JSON file to read.
+ */
+export async function loadStateFromJsonFile(file) {
+  try {
+    const text = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(file);
+    });
+    const textarea = document.getElementById("state-json-input");
+    if (textarea) textarea.value = text;
+    const state = JSON.parse(text);
+    applyLoadedState(state);
+  } catch (e) {
+    if (typeof alert === "function") {
+      alert("Failed to load state: " + (e && e.message ? e.message : e));
+    }
+  }
+}
+
+/**
+ * Load state from the `state` query parameter if present.
+ * The state is assumed to be compressed with LZString.
+ */
+export function loadStateFromUrl() {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const value = params.get("state");
+    if (!value) return;
+    const json = lz.decompressFromEncodedURIComponent(value);
+    if (!json) throw new Error("Failed to decode state");
+    const state = JSON.parse(json);
+    applyLoadedState(state);
+  } catch (e) {
+    if (typeof alert === "function") {
+      alert("Failed to load state: " + (e && e.message ? e.message : e));
+    }
+  }
+}
+
+/**
+ * Trigger a download of the current state as a JSON file.
+ */
+export function downloadJson() {
+  const state = { people, transactions };
+  const dataStr = JSON.stringify(state);
+  const blob = new Blob([dataStr], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "cost-splits.json";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Clear all people and transactions from the current state.
+ */
+export function resetState() {
+  people.length = 0;
+  transactions.length = 0;
+  collapsedSplit.clear();
+  collapsedDetails.clear();
+  afterChange();
+}
+
+/**
+ * Handle updates after state changes by refreshing derived values.
+ */
+export function afterChange() {
+  updateCurrentStateJson();
+  updateShareableUrl();
+  calculateSummary();
+}

--- a/state.js
+++ b/state.js
@@ -1,0 +1,88 @@
+/**
+ * Compute the amounts paid, owed and net balance for each person.
+ *
+ * @param {string[]} people - List of participant names.
+ * @param {Array<{payer:number,cost:number,splits:number[],items?:Array<{item?:string,cost:number,splits:number[]}>}>} transactions -
+ *   Transactions describing who paid and how the cost is split, optionally
+ *   containing itemized sub-splits.
+ * @returns {{paid:number[], owes:number[], nets:number[]}} Summary arrays for
+ *   each person.
+ */
+export function computeSummary(people, transactions) {
+  const paid = Array(people.length).fill(0);
+  const owes = Array(people.length).fill(0);
+
+  transactions.forEach((t) => {
+    paid[t.payer] += t.cost;
+    if (Array.isArray(t.items) && t.items.length > 0) {
+      const itemsTotal = t.items.reduce((sum, it) => sum + it.cost, 0);
+      if (itemsTotal > 0) {
+        const scale = t.cost / itemsTotal;
+        const personTotals = Array(people.length).fill(0);
+        t.items.forEach((it) => {
+          const effCost = it.cost * scale;
+          const splitSum = it.splits.reduce((a, b) => a + b, 0);
+          if (splitSum > 0) {
+            it.splits.forEach((s, i) => {
+              personTotals[i] += (s / splitSum) * effCost;
+            });
+          }
+        });
+        personTotals.forEach((amt, i) => {
+          owes[i] += amt;
+        });
+      }
+    } else {
+      const totalSplit = t.splits.reduce((a, b) => a + b, 0);
+      if (totalSplit > 0) {
+        t.splits.forEach((s, i) => {
+          owes[i] += (s / totalSplit) * t.cost;
+        });
+      }
+    }
+  });
+
+  const nets = people.map((_, i) => paid[i] - owes[i]);
+  return { paid, owes, nets };
+}
+
+/** @type {string[]} */
+export const people = [];
+/**
+ * @type {Array<{
+ *   name?: string,
+ *   cost: number,
+ *   payer: number,
+ *   splits: number[],
+ *   items?: Array<{ item?: string, cost: number, splits: number[] }>
+ * }>}
+ */
+export const transactions = [];
+/** @type {Set<number>} */
+export const collapsedSplit = new Set();
+/** @type {Set<number>} */
+export const collapsedDetails = new Set();
+
+/**
+ * Check whether a value represents a valid dollar amount.
+ *
+ * @param {string} value - Input string to validate.
+ * @param {boolean} [allowEmpty=false] - Whether an empty string is allowed.
+ * @returns {boolean} True if the value is a valid dollar amount.
+ */
+export function isValidDollar(value, allowEmpty = false) {
+  if (allowEmpty && value.trim() === "") return true;
+  return /^\d+(\.\d{0,2})?$/.test(value);
+}
+
+/**
+ * Validate an arbitrary number allowing any number of decimals.
+ *
+ * @param {string} value - Input string to validate.
+ * @param {boolean} [allowEmpty=false] - Whether an empty string is allowed.
+ * @returns {boolean} True if the value is numeric.
+ */
+export function isValidNumber(value, allowEmpty = false) {
+  if (allowEmpty && value.trim() === "") return true;
+  return /^\d+(\.\d+)?$/.test(value);
+}


### PR DESCRIPTION
## Summary
- Split monolithic `scripts.js` into `state.js`, `render.js`, and `share.js`
- Introduce `main.js` entry and update HTML to load it as an ES module
- Update tests and package config for the new module structure

## Testing
- `npm run lint`
- `npx prettier -c main.js share.js render.js state.js scripts.test.js index.html package.json`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a96ac0488320a9ba9b20ada8cc96