### PR TITLE
refactor: extract styles to stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,84 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Cost Split Calculator</title>
-    <style>
-      body {
-        font-family: Arial, sans-serif;
-        margin: 20px;
-      }
-
-      h2 {
-        margin-top: 30px;
-      }
-
-      input,
-      select {
-        margin: 2px;
-      }
-
-      button {
-        margin: 5px 0;
-        padding: 4px 8px;
-      }
-
-      table,
-      th,
-      td {
-        border: 1px solid black;
-        border-collapse: collapse;
-        padding: 5px;
-      }
-
-      table {
-        margin-top: 10px;
-      }
-
-      #transaction-table {
-        table-layout: auto;
-        width: auto;
-      }
-
-      td,
-      th {
-        text-align: right;
-      }
-
-      td:first-child,
-      th:first-child {
-        text-align: left;
-      }
-
-      /* Removed collapsible styles now that split details are always visible */
-
-      .delete-btn {
-        cursor: pointer;
-        color: red;
-        margin-left: 5px;
-      }
-
-      .collapse-btn {
-        cursor: pointer;
-        margin-right: 5px;
-        font-weight: bold;
-      }
-
-      .unused-row {
-        background-color: yellow;
-      }
-
-      .invalid-cell {
-        background-color: rgba(255, 0, 0, 0.4);
-      }
-
-      .dollar-field {
-        display: flex;
-        align-items: center;
-      }
-
-      .dollar-field .prefix {
-        margin-right: 2px;
-      }
-    </style>
+    <link rel="stylesheet" href="styles.css" />
   </head>
 
   <body>
@@ -108,17 +31,12 @@
     <div id="summary"></div>
 
     <h2>5. Save/Load State</h2>
-    <div style="display: flex; align-items: center; gap: 5px; margin: 5px 0">
+    <div class="flex-row">
       <input
         id="state-json-display"
         type="text"
         readonly
-        style="
-          flex: 1;
-          white-space: nowrap;
-          overflow-x: auto;
-          background-color: #f0f0f0;
-        "
+        class="readonly-field"
         placeholder="Current state JSON"
       />
       <button onclick="downloadJson()">Download JSON File</button>
@@ -138,22 +56,17 @@
       type="file"
       id="state-json-file"
       accept="application/json"
-      style="display: none"
+      class="hidden"
       onchange="loadStateFromJsonFile(this.files[0])"
     />
 
     <h2>6. Share</h2>
-    <div style="display: flex; align-items: center; gap: 5px; margin: 5px 0">
+    <div class="flex-row">
       <input
         id="share-url-display"
         type="text"
         readonly
-        style="
-          flex: 1;
-          white-space: nowrap;
-          overflow-x: auto;
-          background-color: #f0f0f0;
-        "
+        class="readonly-field"
         placeholder="Shareable URL"
       />
     </div>

--- a/scripts.js
+++ b/scripts.js
@@ -360,7 +360,7 @@ function renderSplitTable() {
     if (hasItems && !collapsed) {
       t.items.forEach((it, ii) => {
         const iRow = document.createElement("tr");
-        let cell = `<td style="padding-left:20px;"><input type="text" value="${it.item || ""}" onchange="editItem(${ti},${ii},'item',this.value)"></td>`;
+        let cell = `<td class="indent-cell"><input type="text" value="${it.item || ""}" onchange="editItem(${ti},${ii},'item',this.value)"></td>`;
         cell += `<td><div class="dollar-field"><span class="prefix">$</span><input type="text" value="${it.cost.toFixed(2)}" onchange="editItem(${ti},${ii},'cost',this.value,this)"></div></td>`;
         people.forEach((p, pi) => {
           const raw = it.splits[pi];
@@ -531,7 +531,7 @@ function renderSplitDetails() {
 
   const table = document.createElement("table");
   const colSpan = people.length + 1;
-  let header = `<tr><th colspan="${colSpan}" style="text-align: center;">Split Details</th></tr>`;
+  let header = `<tr><th colspan="${colSpan}" class="text-center">Split Details</th></tr>`;
   header += "<tr><th>Transaction</th>";
   people.forEach((p) => (header += `<th>${p}</th>`));
   header += "</tr>";
@@ -580,7 +580,7 @@ function renderSplitDetails() {
       t.items.forEach((it, ii) => {
         const iRow = document.createElement("tr");
         const itemName = it.item || `Item ${ii + 1}`;
-        let rowCells = `<td style="padding-left:20px;">${itemName} - $${(it.cost * scale).toFixed(2)}</td>`;
+        let rowCells = `<td class="indent-cell">${itemName} - $${(it.cost * scale).toFixed(2)}</td>`;
         const splitSum = it.splits.reduce((a, b) => a + b, 0);
         people.forEach((p, pi) => {
           let portion = 0;

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,102 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+h2 {
+  margin-top: 30px;
+}
+
+input,
+select {
+  margin: 2px;
+}
+
+button {
+  margin: 5px 0;
+  padding: 4px 8px;
+}
+
+table,
+th,
+td {
+  border: 1px solid black;
+  border-collapse: collapse;
+  padding: 5px;
+}
+
+table {
+  margin-top: 10px;
+}
+
+#transaction-table {
+  table-layout: auto;
+  width: auto;
+}
+
+td,
+th {
+  text-align: right;
+}
+
+td:first-child,
+th:first-child {
+  text-align: left;
+}
+
+/* Removed collapsible styles now that split details are always visible */
+
+.delete-btn {
+  cursor: pointer;
+  color: red;
+  margin-left: 5px;
+}
+
+.collapse-btn {
+  cursor: pointer;
+  margin-right: 5px;
+  font-weight: bold;
+}
+
+.unused-row {
+  background-color: yellow;
+}
+
+.invalid-cell {
+  background-color: rgba(255, 0, 0, 0.4);
+}
+
+.dollar-field {
+  display: flex;
+  align-items: center;
+}
+
+.dollar-field .prefix {
+  margin-right: 2px;
+}
+
+.flex-row {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: 5px 0;
+}
+
+.readonly-field {
+  flex: 1;
+  white-space: nowrap;
+  overflow-x: auto;
+  background-color: #f0f0f0;
+}
+
+.hidden {
+  display: none;
+}
+
+.indent-cell {
+  padding-left: 20px;
+}
+
+.text-center {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- move embedded styles into new `styles.css`
- replace inline style attributes with reusable CSS classes
- update scripts to reference new classes

## Testing
- `npx prettier index.html scripts.js styles.css -w`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a9d353e48320bb04f030a4e4222d