### PR TITLE
feat: allow renaming people

### DIFF
--- a/render.js
+++ b/render.js
@@ -91,6 +91,10 @@ function deletePerson(index) {
  */
 function renamePerson(index, newName) {
   const name = newName.trim();
+  const oldName = people[index];
+  if (name === oldName) {
+    return true;
+  }
   if (!name || people.includes(name)) {
     return false;
   }

--- a/scripts.test.js
+++ b/scripts.test.js
@@ -259,6 +259,14 @@ describe("renamePerson", () => {
     expect(inputs[1].value).toBe("Charlie");
   });
 
+  test("accepts unchanged name without error", () => {
+    const result = renamePerson(1, "Bob");
+    expect(result).toBe(true);
+    expect(people[1]).toBe("Bob");
+    const inputs = document.querySelectorAll("#people-list input");
+    expect(inputs[1].value).toBe("Bob");
+  });
+
   test("prevents duplicate names", () => {
     const result = renamePerson(1, "Alice");
     expect(result).toBe(false);


### PR DESCRIPTION
## Summary
- make people list names editable and validate renames
- add `renamePerson` to update people array and refresh UI
- cover rename scenarios with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bb4b95348320b9e59a423bc0a3c5