### PR TITLE
Add input labels and IDs for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
 
     <h2>1. People</h2>
     <div id="people-section">
+      <label for="person-name">Person Name</label>
       <input type="text" id="person-name" placeholder="Name" />
-      <button id="save-people">Add Person</button>
+      <button id="save-people" type="button">Add Person</button>
       <ul id="people-list"></ul>
     </div>
 
@@ -32,6 +33,7 @@
 
     <h2>5. Save/Load State</h2>
     <div class="flex-row">
+      <label for="state-json-display">Current state JSON</label>
       <input
         id="state-json-display"
         type="text"
@@ -39,8 +41,9 @@
         class="readonly-field"
         placeholder="Current state JSON"
       />
-      <button id="download-json">Download JSON File</button>
+      <button id="download-json" type="button">Download JSON File</button>
     </div>
+    <label for="state-json-input">State JSON</label>
     <textarea
       id="state-json-input"
       rows="8"
@@ -48,8 +51,9 @@
       placeholder="State JSON"
     ></textarea>
     <br />
-    <button id="load-json">Load from JSON</button>
-    <button id="load-json-file">Load from JSON File</button>
+    <button id="load-json" type="button">Load from JSON</button>
+    <button id="load-json-file" type="button">Load from JSON File</button>
+    <label for="state-json-file" class="hidden">State JSON File</label>
     <input
       type="file"
       id="state-json-file"
@@ -59,6 +63,7 @@
 
     <h2>6. Share</h2>
     <div class="flex-row">
+      <label for="share-url-display">Shareable URL</label>
       <input
         id="share-url-display"
         type="text"

--- a/render.js
+++ b/render.js
@@ -123,6 +123,8 @@ function renderTransactionTable() {
     const nameInput = document.createElement("input");
     nameInput.type = "text";
     nameInput.value = t.name || `Transaction ${i + 1}`;
+    nameInput.id = `transaction-name-${i}`;
+    nameInput.setAttribute("aria-label", `Transaction ${i + 1} name`);
     nameInput.addEventListener("change", (e) =>
       editTransaction(i, "name", e.target.value, e.target),
     );
@@ -131,6 +133,8 @@ function renderTransactionTable() {
 
     const payerCell = document.createElement("td");
     const payerSelect = document.createElement("select");
+    payerSelect.id = `transaction-payer-${i}`;
+    payerSelect.setAttribute("aria-label", `Transaction ${i + 1} payer`);
     people.forEach((p, pi) => {
       const opt = document.createElement("option");
       opt.value = String(pi);
@@ -153,6 +157,8 @@ function renderTransactionTable() {
     const costInput = document.createElement("input");
     costInput.type = "text";
     costInput.value = t.cost.toFixed(2);
+    costInput.id = `transaction-cost-${i}`;
+    costInput.setAttribute("aria-label", `Transaction ${i + 1} cost`);
     costInput.addEventListener("change", (e) =>
       editTransaction(i, "cost", e.target.value, e.target),
     );
@@ -178,12 +184,14 @@ function renderTransactionTable() {
   addNameInput.type = "text";
   addNameInput.id = "new-t-name";
   addNameInput.placeholder = "Name (optional)";
+  addNameInput.setAttribute("aria-label", "New transaction name");
   addNameCell.appendChild(addNameInput);
   addRow.appendChild(addNameCell);
 
   const addPayerCell = document.createElement("td");
   const addPayerSelect = document.createElement("select");
   addPayerSelect.id = "new-t-payer";
+  addPayerSelect.setAttribute("aria-label", "New transaction payer");
   people.forEach((p, pi) => {
     const opt = document.createElement("option");
     opt.value = String(pi);
@@ -203,6 +211,7 @@ function renderTransactionTable() {
   addCostInput.type = "text";
   addCostInput.id = "new-t-cost";
   addCostInput.placeholder = "Cost";
+  addCostInput.setAttribute("aria-label", "New transaction cost");
   addCostWrapper.appendChild(addPrefix);
   addCostWrapper.appendChild(addCostInput);
   addCostCell.appendChild(addCostWrapper);
@@ -316,7 +325,9 @@ function renderSplitTable() {
       const rawVal = t.splits[pi];
       const val = rawVal ? String(rawVal) : "";
       const disabled = hasItems ? "disabled" : "";
-      cells += `<td><input type="text" value="${val}" ${disabled} data-action="editSplit" data-ti="${ti}" data-pi="${pi}"></td>`;
+      const splitId = `split-${ti}-${pi}`;
+      const ariaLabel = `Split for ${p} in ${tName}`;
+      cells += `<td><input id="${splitId}" type="text" value="${val}" ${disabled} data-action="editSplit" data-ti="${ti}" data-pi="${pi}" aria-label="${ariaLabel}"></td>`;
     });
     if (hasItems) {
       cells += `<td><button data-action="unitemizeTransaction" data-ti="${ti}">Normal</button><button data-action="addItem" data-ti="${ti}">Add Item</button></td>`;
@@ -329,12 +340,16 @@ function renderSplitTable() {
     if (hasItems && !collapsed) {
       t.items.forEach((it, ii) => {
         const iRow = document.createElement("tr");
-        let cell = `<td class="indent-cell"><input type="text" value="${it.item || ""}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="item"></td>`;
-        cell += `<td><div class="dollar-field"><span class="prefix">$</span><input type="text" value="${it.cost.toFixed(2)}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="cost"></div></td>`;
+        const itemNameId = `item-name-${ti}-${ii}`;
+        let cell = `<td class="indent-cell"><input id="${itemNameId}" type="text" value="${it.item || ""}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="item" aria-label="Item ${ii + 1} name for ${tName}"></td>`;
+        const itemCostId = `item-cost-${ti}-${ii}`;
+        cell += `<td><div class="dollar-field"><span class="prefix">$</span><input id="${itemCostId}" type="text" value="${it.cost.toFixed(2)}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="cost" aria-label="Item ${ii + 1} cost for ${tName}"></div></td>`;
         people.forEach((p, pi) => {
           const raw = it.splits[pi];
           const val2 = raw ? String(raw) : "";
-          cell += `<td><input type="text" value="${val2}" data-action="editItemSplit" data-ti="${ti}" data-ii="${ii}" data-pi="${pi}"></td>`;
+          const splitId = `item-split-${ti}-${ii}-${pi}`;
+          const aria = `Split for ${p} in item ${ii + 1} of ${tName}`;
+          cell += `<td><input id="${splitId}" type="text" value="${val2}" data-action="editItemSplit" data-ti="${ti}" data-ii="${ii}" data-pi="${pi}" aria-label="${aria}"></td>`;
         });
         cell += `<td><span class="delete-btn" data-action="deleteItem" data-ti="${ti}" data-ii="${ii}">❌</span></td>`;
         iRow.innerHTML = cell;


### PR DESCRIPTION
## Summary
- label static form inputs and share URL field
- assign IDs and aria-labels to dynamic transaction and split inputs
- mark buttons and file input for better accessibility

## Testing
- `npm run lint`
- `npm test`
- `npx --yes -p htmlhint htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a3bb6263008320a299686f839806a8