### PR TITLE
feat: show inline error messages

### DIFF
--- a/render.js
+++ b/render.js
@@ -10,6 +10,47 @@ import {
   computeSettlements,
 } from "./state.js";
 
+/**
+ * Display an error indicator next to an invalid field.
+ *
+ * @param {HTMLElement} el - Element to mark as invalid.
+ * @param {string} message - Message describing the error.
+ */
+function showError(el, message) {
+  el.classList.add("invalid-cell");
+  let error = el.nextElementSibling;
+  if (!error || !error.classList.contains("error")) {
+    error = document.createElement("span");
+    error.className = "error";
+    error.textContent = "❗";
+    el.insertAdjacentElement("afterend", error);
+  }
+  error.setAttribute("data-error", message);
+  error.setAttribute("aria-label", message);
+  error.setAttribute("role", "alert");
+  error.setAttribute("tabindex", "0");
+  el.addEventListener(
+    "input",
+    () => {
+      clearError(el);
+    },
+    { once: true },
+  );
+}
+
+/**
+ * Remove error indicator from a field if present.
+ *
+ * @param {HTMLElement} el - Element to clear of errors.
+ */
+function clearError(el) {
+  el.classList.remove("invalid-cell");
+  const error = el.nextElementSibling;
+  if (error && error.classList.contains("error")) {
+    error.remove();
+  }
+}
+
 // ---- PEOPLE ----
 
 /**
@@ -19,10 +60,10 @@ function addPerson() {
   const input = document.getElementById("person-name");
   const name = input.value.trim();
   if (!name || people.includes(name)) {
-    input.classList.add("invalid-cell");
+    showError(input, "Name must be unique and non-empty.");
     return;
   }
-  input.classList.remove("invalid-cell");
+  clearError(input);
   people.push(name);
   transactions.forEach((t) => {
     t.splits.push(0);
@@ -117,10 +158,12 @@ function renderPeople() {
     const li = document.createElement("li");
     const input = document.createElement("input");
     input.value = p;
-    input.oninput = () => input.classList.remove("invalid-cell");
+    input.oninput = () => clearError(input);
     input.onblur = () => {
       if (!renamePerson(i, input.value)) {
-        input.classList.add("invalid-cell");
+        showError(input, "Name must be unique and non-empty.");
+      } else {
+        clearError(input);
       }
     };
     input.onkeydown = (e) => {
@@ -250,6 +293,7 @@ function renderTransactionTable() {
   addCostInput.id = "new-t-cost";
   addCostInput.placeholder = "Cost";
   addCostInput.setAttribute("aria-label", "New transaction cost");
+  addCostInput.oninput = () => clearError(addCostInput);
   addCostWrapper.appendChild(addPrefix);
   addCostWrapper.appendChild(addCostInput);
   addCostCell.appendChild(addCostWrapper);
@@ -274,10 +318,10 @@ function addTransaction() {
   const payer = parseInt(document.getElementById("new-t-payer").value);
   const costVal = costInput.value.trim();
   if (!isValidDollar(costVal)) {
-    costInput.classList.add("invalid-cell");
+    showError(costInput, "Enter a valid cost.");
     return;
   }
-  costInput.classList.remove("invalid-cell");
+  clearError(costInput);
   const name = nameInput.value.trim();
   const cost = parseFloat(costVal);
   transactions.push({
@@ -304,10 +348,10 @@ function addTransaction() {
 function editTransaction(i, field, value, el) {
   if (field === "cost") {
     if (!isValidDollar(value)) {
-      el.classList.add("invalid-cell");
+      showError(el, "Enter a valid cost.");
       return;
     }
-    el.classList.remove("invalid-cell");
+    clearError(el);
     transactions[i].cost = parseFloat(value);
     el.value = transactions[i].cost.toFixed(2);
   } else if (field === "payer") {
@@ -463,10 +507,10 @@ function renderSplitTable() {
  */
 function editSplit(ti, pi, value, el) {
   if (!isValidNumber(value, true)) {
-    el.classList.add("invalid-cell");
+    showError(el, "Enter a valid number.");
     return;
   }
-  el.classList.remove("invalid-cell");
+  clearError(el);
   transactions[ti].splits[pi] = value ? parseFloat(value) : 0;
   el.value = value;
   afterChange();
@@ -543,10 +587,10 @@ function editItem(ti, ii, field, value, el) {
   const item = transactions[ti].items[ii];
   if (field === "cost") {
     if (!isValidDollar(value)) {
-      el.classList.add("invalid-cell");
+      showError(el, "Enter a valid cost.");
       return;
     }
-    el.classList.remove("invalid-cell");
+    clearError(el);
     item.cost = parseFloat(value);
     el.value = item.cost.toFixed(2);
   } else if (field === "item") {
@@ -567,10 +611,10 @@ function editItem(ti, ii, field, value, el) {
  */
 function editItemSplit(ti, ii, pi, value, el) {
   if (!isValidNumber(value, true)) {
-    el.classList.add("invalid-cell");
+    showError(el, "Enter a valid number.");
     return;
   }
-  el.classList.remove("invalid-cell");
+  clearError(el);
   transactions[ti].items[ii].splits[pi] = value ? parseFloat(value) : 0;
   afterChange();
   renderSplitDetails();

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,38 @@ th:first-child {
   background-color: rgba(255, 0, 0, 0.4);
 }
 
+.error {
+  color: red;
+  font-weight: bold;
+  margin-left: 4px;
+  cursor: help;
+  position: relative;
+  display: inline-block;
+}
+
+.error::after {
+  content: attr(data-error);
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: 125%;
+  background-color: #fce4e4;
+  color: #a40000;
+  padding: 4px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s;
+  z-index: 10;
+}
+
+.error:hover::after,
+.error:focus::after {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .dollar-field {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add reusable helpers to show or clear inline error indicators
- display tooltip-based error icon when inputs are invalid
- style `.error` for accessible red icon and message bubble

## Testing
- `npx prettier render.js styles.css --check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c38cfd9883209f4ba4024f782a23