### PR TITLE
feat: make interface mobile-friendly

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Cost Split Calculator</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
@@ -18,18 +19,18 @@
     </div>
 
     <h2>2. Transactions</h2>
-    <div id="transactions-section">
+    <div id="transactions-section" class="table-container">
       <table id="transaction-table"></table>
     </div>
 
     <h2>3. Cost Splits</h2>
     <div id="splits-section">
-      <div id="split-table"></div>
+      <div id="split-table" class="table-container"></div>
       <div id="split-details"></div>
     </div>
 
     <h2>4. Summary</h2>
-    <div id="summary"></div>
+    <div id="summary" class="table-container"></div>
 
     <h2>5. Save/Load State</h2>
     <div class="flex-row">

--- a/styles.css
+++ b/styles.css
@@ -1,37 +1,38 @@
 body {
   font-family: Arial, sans-serif;
-  margin: 20px;
+  margin: 1.25rem;
 }
 
 h2 {
-  margin-top: 30px;
+  margin-top: 1.875rem;
 }
 
 input,
 select {
-  margin: 2px;
+  margin: 0.125rem;
 }
 
 button {
-  margin: 5px 0;
-  padding: 4px 8px;
+  margin: 0.3125rem 0;
+  padding: 0.5rem 1rem;
 }
 
 table,
 th,
 td {
-  border: 1px solid black;
+  border: 0.0625rem solid black;
   border-collapse: collapse;
-  padding: 5px;
+  padding: 0.3125rem;
 }
 
 table {
-  margin-top: 10px;
+  margin-top: 0.625rem;
+  width: 100%;
 }
 
 #transaction-table {
   table-layout: auto;
-  width: auto;
+  width: 100%;
 }
 
 th {
@@ -49,12 +50,12 @@ td:first-child {
 .delete-btn {
   cursor: pointer;
   color: red;
-  margin-left: 5px;
+  margin-left: 0.3125rem;
 }
 
 .collapse-btn {
   cursor: pointer;
-  margin-right: 5px;
+  margin-right: 0.3125rem;
   font-weight: bold;
 }
 
@@ -69,7 +70,7 @@ td:first-child {
 .error {
   color: red;
   font-weight: bold;
-  margin-left: 4px;
+  margin-left: 0.25rem;
   cursor: help;
   position: relative;
   display: inline-block;
@@ -83,8 +84,8 @@ td:first-child {
   bottom: 125%;
   background-color: #fce4e4;
   color: #a40000;
-  padding: 4px 8px;
-  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
   white-space: nowrap;
   opacity: 0;
   pointer-events: none;
@@ -104,14 +105,14 @@ td:first-child {
 }
 
 .dollar-field .prefix {
-  margin-right: 2px;
+  margin-right: 0.125rem;
 }
 
 .flex-row {
   display: flex;
   align-items: center;
-  gap: 5px;
-  margin: 5px 0;
+  gap: 0.3125rem;
+  margin: 0.3125rem 0;
 }
 
 .readonly-field {
@@ -126,9 +127,47 @@ td:first-child {
 }
 
 .indent-cell {
-  padding-left: 20px;
+  padding-left: 1.25rem;
 }
 
 .text-center {
   text-align: center;
+}
+
+.table-container {
+  width: 100%;
+  overflow-x: auto;
+}
+
+@media (max-width: 600px) {
+  .flex-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  button {
+    padding: 0.25rem 0.5rem;
+  }
+
+  table,
+  th,
+  td {
+    padding: 0.25rem;
+  }
+
+  .table-container tr {
+    display: block;
+    margin-bottom: 0.625rem;
+  }
+
+  .table-container th,
+  .table-container td {
+    display: block;
+    width: 100%;
+    text-align: right;
+  }
+
+  .table-container td:first-child {
+    text-align: left;
+  }
 }


### PR DESCRIPTION
## Summary
- add viewport meta tag for proper scaling on mobile
- convert margins/padding to rem units and wrap tables in scrollable containers
- add mobile breakpoint to stack controls and simplify tables on narrow screens

## Testing
- `npx prettier . --check`
- `npm run lint`
- `npm test`
- `node <<'NODE' ... NODE` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d0deba048320911ac583e89465b2