### PR TITLE
refactor: modernize theme with CSS variables

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -51,7 +51,8 @@ h2 {
 }
 
 input,
-select {
+select,
+textarea {
   margin: calc(var(--spacing) / 4);
   padding: calc(var(--spacing) / 2);
   border: 1px solid var(--border-color);

--- a/styles.css
+++ b/styles.css
@@ -1,39 +1,95 @@
+/* Theme variables */
+:root {
+  --primary-color: #2a7ae2;
+  --border-color: #ccc;
+  --background-color: #fff;
+  --text-color: #222;
+  --muted-bg: #f0f0f0;
+  --alt-row-bg: #f9f9f9;
+  --danger-color: #d9534f;
+  --warning-bg: #fff8c4;
+  --error-bg: rgba(217, 83, 79, 0.2);
+  --error-tooltip-bg: #fce4e4;
+  --error-tooltip-color: #a40000;
+  --spacing: 0.5rem;
+  --font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-color: #121212;
+    --text-color: #eee;
+    --border-color: #555;
+    --muted-bg: #1e1e1e;
+    --alt-row-bg: #1a1a1a;
+    --primary-color: #569aff;
+    --danger-color: #ff7b72;
+    --warning-bg: #665c00;
+    --error-bg: rgba(255, 123, 114, 0.2);
+    --error-tooltip-bg: #3d1a1a;
+    --error-tooltip-color: #ff7b72;
+  }
+}
+
 html {
   font-size: clamp(14px, 2vw, 16px);
 }
 
 body {
-  font-family: Arial, sans-serif;
+  font-family: var(--font-family);
   max-width: 60rem;
   margin: 0 auto;
-  padding: 1.25rem;
+  padding: calc(var(--spacing) * 2.5);
+  background-color: var(--background-color);
+  color: var(--text-color);
 }
 
 h2 {
-  margin-top: 1.875rem;
+  margin-top: calc(var(--spacing) * 4);
 }
 
 input,
 select {
-  margin: 0.125rem;
+  margin: calc(var(--spacing) / 4);
+  padding: calc(var(--spacing) / 2);
+  border: 1px solid var(--border-color);
+  background-color: var(--background-color);
+  color: var(--text-color);
+  border-radius: 0.25rem;
 }
 
 button {
-  margin: 0.3125rem 0;
-  padding: 0.5rem 1rem;
+  margin: calc(var(--spacing) / 2) 0;
+  padding: var(--spacing) calc(var(--spacing) * 2);
+  background-color: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: filter 0.2s;
 }
 
-table,
-th,
-td {
-  border: 0.0625rem solid black;
-  border-collapse: collapse;
-  padding: 0.3125rem;
+button:hover,
+button:focus {
+  filter: brightness(0.9);
 }
 
 table {
-  margin-top: 0.625rem;
+  margin-top: calc(var(--spacing) * 1.25);
   width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: calc(var(--spacing) / 2);
+  border-bottom: 1px solid var(--border-color);
+}
+
+tbody tr:nth-child(even) {
+  background-color: var(--alt-row-bg);
 }
 
 #transaction-table {
@@ -55,28 +111,28 @@ td:first-child {
 
 .delete-btn {
   cursor: pointer;
-  color: red;
-  margin-left: 0.3125rem;
+  color: var(--danger-color);
+  margin-left: calc(var(--spacing) / 2);
 }
 
 .collapse-btn {
   cursor: pointer;
-  margin-right: 0.3125rem;
+  margin-right: calc(var(--spacing) / 2);
   font-weight: bold;
 }
 
 .unused-row {
-  background-color: yellow;
+  background-color: var(--warning-bg);
 }
 
 .invalid-cell {
-  background-color: rgba(255, 0, 0, 0.4);
+  background-color: var(--error-bg);
 }
 
 .error {
-  color: red;
+  color: var(--danger-color);
   font-weight: bold;
-  margin-left: 0.25rem;
+  margin-left: calc(var(--spacing) / 2);
   cursor: help;
   position: relative;
   display: inline-block;
@@ -88,10 +144,10 @@ td:first-child {
   left: 50%;
   transform: translateX(-50%);
   bottom: 125%;
-  background-color: #fce4e4;
-  color: #a40000;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
+  background-color: var(--error-tooltip-bg);
+  color: var(--error-tooltip-color);
+  padding: calc(var(--spacing) / 2) var(--spacing);
+  border-radius: calc(var(--spacing) / 2);
   white-space: nowrap;
   opacity: 0;
   pointer-events: none;
@@ -111,7 +167,7 @@ td:first-child {
 }
 
 .dollar-field .prefix {
-  margin-right: 0.125rem;
+  margin-right: calc(var(--spacing) / 4);
 }
 
 .dollar-field input {
@@ -128,15 +184,17 @@ input[data-action="editItemSplit"] {
 .flex-row {
   display: flex;
   align-items: center;
-  gap: 0.3125rem;
-  margin: 0.3125rem 0;
+  gap: calc(var(--spacing) / 2);
+  margin: calc(var(--spacing) / 2) 0;
 }
 
 .readonly-field {
   flex: 1;
   white-space: nowrap;
   overflow-x: auto;
-  background-color: #f0f0f0;
+  background-color: var(--muted-bg);
+  border: 1px solid var(--border-color);
+  padding: calc(var(--spacing) / 2);
 }
 
 .hidden {
@@ -144,7 +202,7 @@ input[data-action="editItemSplit"] {
 }
 
 .indent-cell {
-  padding-left: 1.25rem;
+  padding-left: calc(var(--spacing) * 2.5);
 }
 
 .text-center {
@@ -163,16 +221,16 @@ input[data-action="editItemSplit"] {
   }
 
   body {
-    padding: 0.5rem;
+    padding: var(--spacing);
   }
 
   button {
-    padding: 0.25rem 0.5rem;
+    padding: calc(var(--spacing) / 2) var(--spacing);
   }
 
   table,
   th,
   td {
-    padding: 0.25rem;
+    padding: calc(var(--spacing) / 2);
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -204,6 +204,17 @@ input[data-action="editItemSplit"] {
 
 .indent-cell {
   padding-left: calc(var(--spacing) * 2.5);
+  position: relative;
+}
+
+.indent-cell::before {
+  content: "↳";
+  position: absolute;
+  left: var(--spacing);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--primary-color);
+  pointer-events: none;
 }
 
 .text-center {


### PR DESCRIPTION
## Summary
- establish CSS custom properties with light and dark color schemes
- switch to a system font stack and update borders, inputs, and buttons
- simplify tables with subtle dividers and zebra striping

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3dbfe338c832099928e920b8b3711