### PR TITLE
feat: allow naming transaction pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ groups. Try the live demo at
 - Responsive design that works on mobile and desktop
 - Itemized transactions with proportional tax and tip
 - Shareable URLs encoding the current calculator state
+- Optional session pool name to label each set of transactions
 
 ## Getting Started
 
@@ -26,6 +27,9 @@ Serve `index.html` with any static server or open the file directly in a
 browser.
 
 ## Usage
+
+Before adding participants, optionally enter a name for your pool of
+transactions using the field beneath the page title.
 
 1. Add participants and transactions.
 2. Use the ▶/▼ controls to itemize a transaction when needed.

--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
   <body>
     <h1>Cost Split Calculator</h1>
 
+    <div id="pool-section">
+      <label for="pool-name" class="hidden">Pool Name</label>
+      <input type="text" id="pool-name" placeholder="Pool name" />
+    </div>
+
     <h2>1. People</h2>
     <div id="people-section">
       <label for="person-name" class="hidden">Person Name</label>

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { setAfterChange } from "./state.js";
+import { setAfterChange, setPool } from "./state.js";
 import { calculateSummary, addPerson } from "./render.js";
 import {
   updateCurrentStateJson,
@@ -19,6 +19,9 @@ setAfterChange(() => {
 loadStateFromUrl();
 
 // UI bindings
+document
+  .getElementById("pool-name")
+  .addEventListener("input", (e) => setPool(e.target.value));
 document.getElementById("save-people").addEventListener("click", addPerson);
 document
   .getElementById("download-json")

--- a/src/share.js
+++ b/src/share.js
@@ -1,4 +1,6 @@
 import {
+  pool,
+  setPool,
   people,
   transactions,
   collapsedSplit,
@@ -36,6 +38,10 @@ function validateState(state) {
     !Array.isArray(state.transactions)
   ) {
     throw new Error("Invalid state: missing people or transactions arrays");
+  }
+
+  if (typeof state.pool !== "undefined" && typeof state.pool !== "string") {
+    throw new Error("Invalid state: pool must be a string");
   }
 
   // Validate people: array of non-empty strings
@@ -84,7 +90,7 @@ function validateState(state) {
  */
 function updateCurrentStateJson() {
   const display = document.getElementById("state-json-display");
-  const state = { people, transactions };
+  const state = { pool, people, transactions };
   if (display) display.value = JSON.stringify(state);
 }
 
@@ -97,7 +103,7 @@ function updateShareableUrl() {
   const display = document.getElementById("share-url-display");
   if (!display || typeof window === "undefined") return;
   const base = window.location.href.split(/[?#]/)[0];
-  const json = JSON.stringify({ people, transactions });
+  const json = JSON.stringify({ pool, people, transactions });
   const compressed = lz.compressToEncodedURIComponent(json);
   display.value = `${base}?state=${compressed}`;
 }
@@ -113,8 +119,12 @@ function applyLoadedState(state) {
   transactions.length = 0;
   collapsedSplit.clear();
   collapsedDetails.clear();
+  setPool(typeof state.pool === "string" ? state.pool : "");
   state.people.forEach((p) => people.push(p));
   state.transactions.forEach((t) => transactions.push(t));
+
+  const poolInput = document.getElementById("pool-name");
+  if (poolInput) poolInput.value = pool;
 
   if (
     typeof renderPeople === "function" &&
@@ -204,7 +214,7 @@ function loadStateFromUrl() {
  * Trigger a download of the current state as a JSON file.
  */
 function downloadJson() {
-  const state = { people, transactions };
+  const state = { pool, people, transactions };
   const dataStr = JSON.stringify(state);
   const blob = new Blob([dataStr], { type: "application/json" });
   const url = URL.createObjectURL(blob);

--- a/src/state.js
+++ b/src/state.js
@@ -88,6 +88,8 @@ export function computeSettlements(people, transactions) {
   return settlements;
 }
 
+/** @type {string} */
+export let pool = "";
 /** @type {string[]} */
 export const people = [];
 /**
@@ -123,6 +125,17 @@ export function setAfterChange(fn) {
  */
 export function afterChange() {
   afterChangeHandler();
+}
+
+/**
+ * Update the global pool name and notify listeners of the change.
+ *
+ * @param {string} name - The new pool name.
+ * @returns {void}
+ */
+export function setPool(name) {
+  pool = name;
+  afterChange();
 }
 
 /**
@@ -162,5 +175,6 @@ export function resetState() {
   transactions.length = 0;
   collapsedSplit.clear();
   collapsedDetails.clear();
+  pool = "";
   afterChange();
 }

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -123,6 +123,7 @@ describe("calculateSummary settlements", () => {
 describe("updateCurrentStateJson and loadStateFromJson", () => {
   beforeEach(() => {
     document.body.innerHTML = `
+      <input id="pool-name" />
       <input id="state-json-display" />
       <textarea id="state-json-input"></textarea>
       <input id="state-json-file" type="file" />
@@ -141,7 +142,7 @@ describe("updateCurrentStateJson and loadStateFromJson", () => {
     document.getElementById("person-name").value = "Alice";
     addPerson();
     expect(document.getElementById("state-json-display").value).toBe(
-      JSON.stringify({ people: ["Alice"], transactions: [] }),
+      JSON.stringify({ pool: "", people: ["Alice"], transactions: [] }),
     );
   });
 
@@ -179,6 +180,7 @@ describe("updateCurrentStateJson and loadStateFromJson", () => {
         ],
       },
     ]);
+    expect(document.getElementById("pool-name").value).toBe("");
   });
 
   test("rejects invalid state", () => {
@@ -254,7 +256,7 @@ describe("downloadJson", () => {
       reader.readAsText(blob);
     });
     expect(text).toBe(
-      JSON.stringify({ people: ["Eve"], transactions: transactions }),
+      JSON.stringify({ pool: "", people: ["Eve"], transactions: transactions }),
     );
     expect(URL.revokeObjectURL).toHaveBeenCalledWith("mockurl");
   });
@@ -359,6 +361,7 @@ describe("editSplit", () => {
 describe("sharing", () => {
   beforeEach(() => {
     document.body.innerHTML = `
+      <input id="pool-name" />
       <input id="state-json-display" />
       <textarea id="state-json-input"></textarea>
       <input id="state-json-file" type="file" />
@@ -379,6 +382,7 @@ describe("sharing", () => {
     transactions.push({ payer: 0, cost: 10, splits: [1] });
     updateShareableUrl();
     const json = JSON.stringify({
+      pool: "",
       people: ["Alice"],
       transactions: transactions,
     });
@@ -390,6 +394,7 @@ describe("sharing", () => {
 
   test("loadStateFromUrl loads state when param present", () => {
     const state = {
+      pool: "",
       people: ["Bob"],
       transactions: [{ payer: 0, cost: 5, splits: [1] }],
     };


### PR DESCRIPTION
## Summary
- add optional pool name input beneath page header
- include pool name in saved JSON and shareable links
- document and test the pool naming feature

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4170b38908320901361fab3f22b4b