### PR TITLE
feat: add local storage helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ groups. Try the live demo at
 - Shareable URLs encoding the current calculator state
 - Optional session pool name to label each set of transactions
 - Save and load named pools using browser local storage with a table of saved
-  pools for quick loading or deletion
+  pools for quick loading or deletion, highlighting the active pool and offering
+  a quick **New Pool** reset
 
 ## Getting Started
 
@@ -31,9 +32,9 @@ browser.
 ## Usage
 
 Before adding participants, optionally enter a name for your pool of
-transactions using the field beneath the page title. Use the adjacent **Save
-Pool** button to store the pool locally and the table below to reload or delete
-previously saved pools.
+transactions using the field beneath the page title. Use the **New Pool** button
+to start over or the **Save Pool** button to store the pool locally. The table
+below highlights the current pool and lets you reload or delete saved pools.
 
 1. Add participants and transactions.
 2. Use the ▶/▼ controls to itemize a transaction when needed.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ groups. Try the live demo at
 - Itemized transactions with proportional tax and tip
 - Shareable URLs encoding the current calculator state
 - Optional session pool name to label each set of transactions
+- Save and load named pools using browser local storage with a drop-down pool
+  picker for quick loading
 
 ## Getting Started
 
@@ -29,7 +31,9 @@ browser.
 ## Usage
 
 Before adding participants, optionally enter a name for your pool of
-transactions using the field beneath the page title.
+transactions using the field beneath the page title. Use the adjacent **Save
+Pool** button to store the pool locally and the drop-down to reload previously
+saved pools.
 
 1. Add participants and transactions.
 2. Use the ▶/▼ controls to itemize a transaction when needed.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ groups. Try the live demo at
 - Itemized transactions with proportional tax and tip
 - Shareable URLs encoding the current calculator state
 - Optional session pool name to label each set of transactions
-- Save and load named pools using browser local storage with a drop-down pool
-  picker for quick loading
+- Save and load named pools using browser local storage with a table of saved
+  pools for quick loading or deletion
 
 ## Getting Started
 
@@ -32,8 +32,8 @@ browser.
 
 Before adding participants, optionally enter a name for your pool of
 transactions using the field beneath the page title. Use the adjacent **Save
-Pool** button to store the pool locally and the drop-down to reload previously
-saved pools.
+Pool** button to store the pool locally and the table below to reload or delete
+previously saved pools.
 
 1. Add participants and transactions.
 2. Use the ▶/▼ controls to itemize a transaction when needed.

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <div id="pool-section">
       <label for="pool-name" class="hidden">Pool Name</label>
       <input type="text" id="pool-name" placeholder="Pool name" />
+      <button id="new-pool" type="button">New Pool</button>
       <button id="save-local" type="button">Save Pool</button>
       <div class="table-container">
         <table id="saved-pools-table"></table>

--- a/index.html
+++ b/index.html
@@ -15,8 +15,9 @@
       <label for="pool-name" class="hidden">Pool Name</label>
       <input type="text" id="pool-name" placeholder="Pool name" />
       <button id="save-local" type="button">Save Pool</button>
-      <label for="saved-pools-picker" class="hidden">Saved Pools</label>
-      <select id="saved-pools-picker"></select>
+      <div class="table-container">
+        <table id="saved-pools-table"></table>
+      </div>
     </div>
 
     <h2>1. People</h2>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
     <div id="pool-section">
       <label for="pool-name" class="hidden">Pool Name</label>
       <input type="text" id="pool-name" placeholder="Pool name" />
+      <button id="save-local" type="button">Save Pool</button>
+      <label for="saved-pools-picker" class="hidden">Saved Pools</label>
+      <select id="saved-pools-picker"></select>
     </div>
 
     <h2>1. People</h2>

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import {
   loadStateFromJsonFile,
   downloadJson,
   savePoolToLocalStorage,
+  startNewPool,
 } from "./share.js";
 
 setAfterChange(() => {
@@ -38,19 +39,23 @@ document.getElementById("save-people").addEventListener("click", addPerson);
 document
   .getElementById("download-json")
   .addEventListener("click", downloadJson);
-document
-  .getElementById("load-json")
-  .addEventListener("click", loadStateFromJson);
+document.getElementById("load-json").addEventListener("click", () => {
+  loadStateFromJson();
+  renderSavedPoolsTable();
+});
 document
   .getElementById("load-json-file")
   .addEventListener("click", () =>
     document.getElementById("state-json-file").click(),
   );
-document.getElementById("state-json-file").addEventListener("change", (e) => {
-  if (e.target.files[0]) {
-    loadStateFromJsonFile(e.target.files[0]);
-  }
-});
+document
+  .getElementById("state-json-file")
+  .addEventListener("change", async (e) => {
+    if (e.target.files[0]) {
+      await loadStateFromJsonFile(e.target.files[0]);
+      renderSavedPoolsTable();
+    }
+  });
 
 document.getElementById("save-local").addEventListener("click", () => {
   if (!pool) {
@@ -58,6 +63,11 @@ document.getElementById("save-local").addEventListener("click", () => {
     return;
   }
   savePoolToLocalStorage(pool, { people, transactions });
+  renderSavedPoolsTable();
+});
+
+document.getElementById("new-pool").addEventListener("click", () => {
+  startNewPool();
   renderSavedPoolsTable();
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -14,8 +14,7 @@ import {
   loadStateFromJsonFile,
   downloadJson,
   savePoolToLocalStorage,
-  loadPoolFromLocalStorage,
-  renderSavedPoolsPicker,
+  renderSavedPoolsTable,
 } from "./share.js";
 
 setAfterChange(() => {
@@ -26,7 +25,7 @@ setAfterChange(() => {
 
 // initial load
 loadStateFromUrl();
-renderSavedPoolsPicker();
+renderSavedPoolsTable();
 
 // UI bindings
 document
@@ -56,16 +55,8 @@ document.getElementById("save-local").addEventListener("click", () => {
     return;
   }
   savePoolToLocalStorage(pool, { people, transactions });
-  renderSavedPoolsPicker();
+  renderSavedPoolsTable();
 });
-
-document
-  .getElementById("saved-pools-picker")
-  .addEventListener("change", (e) => {
-    if (e.target.value) {
-      loadPoolFromLocalStorage(e.target.value);
-    }
-  });
 
 export * from "./state.js";
 export * from "./render.js";

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,11 @@ import {
   people,
   transactions,
 } from "./state.js";
-import { calculateSummary, addPerson } from "./render.js";
+import {
+  calculateSummary,
+  addPerson,
+  renderSavedPoolsTable,
+} from "./render.js";
 import {
   updateCurrentStateJson,
   updateShareableUrl,
@@ -14,7 +18,6 @@ import {
   loadStateFromJsonFile,
   downloadJson,
   savePoolToLocalStorage,
-  renderSavedPoolsTable,
 } from "./share.js";
 
 setAfterChange(() => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,10 @@
-import { setAfterChange, setPool } from "./state.js";
+import {
+  setAfterChange,
+  setPool,
+  pool,
+  people,
+  transactions,
+} from "./state.js";
 import { calculateSummary, addPerson } from "./render.js";
 import {
   updateCurrentStateJson,
@@ -7,6 +13,9 @@ import {
   loadStateFromJson,
   loadStateFromJsonFile,
   downloadJson,
+  savePoolToLocalStorage,
+  loadPoolFromLocalStorage,
+  renderSavedPoolsPicker,
 } from "./share.js";
 
 setAfterChange(() => {
@@ -17,6 +26,7 @@ setAfterChange(() => {
 
 // initial load
 loadStateFromUrl();
+renderSavedPoolsPicker();
 
 // UI bindings
 document
@@ -39,6 +49,23 @@ document.getElementById("state-json-file").addEventListener("change", (e) => {
     loadStateFromJsonFile(e.target.files[0]);
   }
 });
+
+document.getElementById("save-local").addEventListener("click", () => {
+  if (!pool) {
+    alert("Enter a pool name before saving");
+    return;
+  }
+  savePoolToLocalStorage(pool, { people, transactions });
+  renderSavedPoolsPicker();
+});
+
+document
+  .getElementById("saved-pools-picker")
+  .addEventListener("change", (e) => {
+    if (e.target.value) {
+      loadPoolFromLocalStorage(e.target.value);
+    }
+  });
 
 export * from "./state.js";
 export * from "./render.js";

--- a/src/render.js
+++ b/src/render.js
@@ -8,6 +8,7 @@ import {
   isValidNumber,
   computeSummary,
   computeSettlements,
+  pool,
 } from "./state.js";
 import {
   loadPoolFromLocalStorage,
@@ -64,7 +65,7 @@ function clearError(el) {
 // ---- SAVED POOLS ----
 
 /**
- * Render a table of saved pools with load and delete actions.
+ * Render a table of saved pools with load/delete actions and active highlight.
  *
  * @returns {void}
  */
@@ -121,7 +122,13 @@ function renderSavedPoolsTable() {
     actionsCell.appendChild(deleteBtn);
     row.appendChild(actionsCell);
 
-    row.addEventListener("click", () => loadPoolFromLocalStorage(name));
+    if (name === pool) {
+      row.classList.add("active-pool");
+    }
+    row.addEventListener("click", () => {
+      loadPoolFromLocalStorage(name);
+      renderSavedPoolsTable();
+    });
     tbody.appendChild(row);
   });
 

--- a/src/share.js
+++ b/src/share.js
@@ -22,7 +22,7 @@ if (!lz) {
   lz = mod.default;
 }
 
-const LOCAL_STORAGE_KEY = "costSplitPools";
+export const LOCAL_STORAGE_KEY = "costSplitPools";
 
 // ---- SAVE/LOAD STATE ----
 // Validate the structure and types of the loaded state
@@ -291,71 +291,6 @@ function deletePoolFromLocalStorage(name) {
 }
 
 /**
- * Render a table of saved pools with load and delete actions.
- *
- * @returns {void}
- */
-function renderSavedPoolsTable() {
-  const table = document.getElementById("saved-pools-table");
-  if (!table || typeof localStorage === "undefined") return;
-  table.innerHTML = "";
-
-  const thead = document.createElement("thead");
-  const headerRow = document.createElement("tr");
-  ["Pool", "People", "Transactions", "Actions"].forEach((h) => {
-    const th = document.createElement("th");
-    th.textContent = h;
-    headerRow.appendChild(th);
-  });
-  thead.appendChild(headerRow);
-  table.appendChild(thead);
-
-  const tbody = document.createElement("tbody");
-  let pools;
-  try {
-    const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
-    pools = raw ? JSON.parse(raw) : {};
-  } catch (e) {
-    pools = {};
-  }
-
-  Object.entries(pools).forEach(([name, data]) => {
-    const row = document.createElement("tr");
-    const nameCell = document.createElement("td");
-    nameCell.textContent = name;
-    row.appendChild(nameCell);
-
-    const peopleCell = document.createElement("td");
-    peopleCell.textContent = Array.isArray(data.people)
-      ? data.people.length
-      : 0;
-    row.appendChild(peopleCell);
-
-    const txCell = document.createElement("td");
-    txCell.textContent = Array.isArray(data.transactions)
-      ? data.transactions.length
-      : 0;
-    row.appendChild(txCell);
-
-    const actionsCell = document.createElement("td");
-    const deleteBtn = document.createElement("button");
-    deleteBtn.textContent = "Delete";
-    deleteBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      deletePoolFromLocalStorage(name);
-      renderSavedPoolsTable();
-    });
-    actionsCell.appendChild(deleteBtn);
-    row.appendChild(actionsCell);
-
-    row.addEventListener("click", () => loadPoolFromLocalStorage(name));
-    tbody.appendChild(row);
-  });
-
-  table.appendChild(tbody);
-}
-
-/**
  * Trigger a download of the current state as a JSON file.
  */
 function downloadJson() {
@@ -382,7 +317,6 @@ export {
   loadPoolFromLocalStorage,
   listSavedPools,
   deletePoolFromLocalStorage,
-  renderSavedPoolsTable,
   downloadJson,
   validateState,
   applyLoadedState,

--- a/src/share.js
+++ b/src/share.js
@@ -291,6 +291,18 @@ function deletePoolFromLocalStorage(name) {
 }
 
 /**
+ * Start a new, empty pool and refresh the UI.
+ *
+ * Resets people, transactions and pool name using the existing state
+ * application logic.
+ *
+ * @returns {void}
+ */
+function startNewPool() {
+  applyLoadedState({ pool: "", people: [], transactions: [] });
+}
+
+/**
  * Trigger a download of the current state as a JSON file.
  */
 function downloadJson() {
@@ -317,6 +329,7 @@ export {
   loadPoolFromLocalStorage,
   listSavedPools,
   deletePoolFromLocalStorage,
+  startNewPool,
   downloadJson,
   validateState,
   applyLoadedState,

--- a/styles.css
+++ b/styles.css
@@ -93,6 +93,16 @@ tbody tr:nth-child(even) {
   background-color: var(--alt-row-bg);
 }
 
+#saved-pools-table tr.active-pool {
+  background-color: var(--primary-color);
+  color: #fff;
+}
+
+#saved-pools-table tr.active-pool button {
+  background-color: #fff;
+  color: var(--primary-color);
+}
+
 #transaction-table {
   table-layout: auto;
   width: 100%;

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -26,7 +26,7 @@ import {
   savePoolToLocalStorage,
   loadPoolFromLocalStorage,
   listSavedPools,
-  renderSavedPoolsPicker,
+  renderSavedPoolsTable,
   downloadJson,
 } from "../src/share.js";
 import lz from "lz-string";
@@ -424,7 +424,7 @@ describe("local storage helpers", () => {
       <div id="split-table"></div>
       <div id="split-details"></div>
       <input id="share-url-display" />
-      <select id="saved-pools-picker"></select>
+      <table id="saved-pools-table"></table>
     `;
     resetState();
     localStorage.clear();
@@ -446,21 +446,20 @@ describe("local storage helpers", () => {
     expect(listSavedPools().sort()).toEqual(["a", "b"]);
   });
 
-  test("renderSavedPoolsPicker populates DOM and loads pool", () => {
+  test("renderSavedPoolsTable populates DOM, loads and deletes pool", () => {
     people.push("Ann");
     transactions.push({ payer: 0, cost: 5, splits: [1] });
     savePoolToLocalStorage("picnic", { people, transactions });
     resetState();
-    renderSavedPoolsPicker();
-    const select = document.getElementById("saved-pools-picker");
-    const options = Array.from(select.options).map((o) => o.textContent);
-    expect(options).toContain("picnic");
-    select.addEventListener("change", (e) =>
-      loadPoolFromLocalStorage(e.target.value),
-    );
-    select.value = "picnic";
-    select.dispatchEvent(new Event("change"));
+    renderSavedPoolsTable();
+    const row = document.querySelector("#saved-pools-table tbody tr");
+    expect(row).not.toBeNull();
+    row.click();
     expect(people).toEqual(["Ann"]);
     expect(transactions).toEqual([{ payer: 0, cost: 5, splits: [1] }]);
+    renderSavedPoolsTable();
+    const btn = document.querySelector("#saved-pools-table tbody tr button");
+    btn.click();
+    expect(listSavedPools()).toEqual([]);
   });
 });

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -7,6 +7,8 @@ import {
   resetState,
   people,
   transactions,
+  pool,
+  setPool,
   setAfterChange,
 } from "../src/state.js";
 import {
@@ -27,6 +29,7 @@ import {
   savePoolToLocalStorage,
   loadPoolFromLocalStorage,
   listSavedPools,
+  startNewPool,
   downloadJson,
 } from "../src/share.js";
 import lz from "lz-string";
@@ -430,6 +433,18 @@ describe("local storage helpers", () => {
     localStorage.clear();
   });
 
+  test("startNewPool resets state and clears pool name", () => {
+    people.push("Old");
+    transactions.push({ payer: 0, cost: 1, splits: [1] });
+    setPool("existing");
+    document.getElementById("pool-name").value = "existing";
+    startNewPool();
+    expect(people).toEqual([]);
+    expect(transactions).toEqual([]);
+    expect(pool).toBe("");
+    expect(document.getElementById("pool-name").value).toBe("");
+  });
+
   test("save and load pool round trip", () => {
     people.push("Alice");
     transactions.push({ payer: 0, cost: 10, splits: [1] });
@@ -446,7 +461,7 @@ describe("local storage helpers", () => {
     expect(listSavedPools().sort()).toEqual(["a", "b"]);
   });
 
-  test("renderSavedPoolsTable populates DOM, loads and deletes pool", () => {
+  test("renderSavedPoolsTable populates DOM, highlights and deletes pool", () => {
     people.push("Ann");
     transactions.push({ payer: 0, cost: 5, splits: [1] });
     savePoolToLocalStorage("picnic", { people, transactions });
@@ -457,8 +472,11 @@ describe("local storage helpers", () => {
     row.click();
     expect(people).toEqual(["Ann"]);
     expect(transactions).toEqual([{ payer: 0, cost: 5, splits: [1] }]);
-    renderSavedPoolsTable();
-    const btn = document.querySelector("#saved-pools-table tbody tr button");
+    const active = document.querySelector(
+      "#saved-pools-table tbody tr.active-pool",
+    );
+    expect(active).not.toBeNull();
+    const btn = active.querySelector("button");
     btn.click();
     expect(listSavedPools()).toEqual([]);
   });

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -16,6 +16,7 @@ import {
   renderSplitTable,
   editSplit,
   calculateSummary,
+  renderSavedPoolsTable,
 } from "../src/render.js";
 import {
   updateCurrentStateJson,
@@ -26,7 +27,6 @@ import {
   savePoolToLocalStorage,
   loadPoolFromLocalStorage,
   listSavedPools,
-  renderSavedPoolsTable,
   downloadJson,
 } from "../src/share.js";
 import lz from "lz-string";


### PR DESCRIPTION
## Summary
- add helpers to save, load, and list pools via localStorage
- validate and render loaded pools with existing logic
- display saved pools with load buttons in the UI
- document local storage feature
- move save button near pool name and add drop-down pool picker

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a41d872e508320b617fde6b7487dad