### PR TITLE
feat: add theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ groups. Try the live demo at
 ## Features
 
 - Responsive design that works on mobile and desktop
+- Light and dark themes with a sun/moon toggle that remembers your choice
 - Itemized transactions with proportional tax and tip
 - Shareable URLs encoding the current calculator state
 - Optional session pool name to label each set of transactions

--- a/index.html
+++ b/index.html
@@ -11,9 +11,13 @@
   <body>
     <div class="flex-row">
       <h1>Cost Split Calculator</h1>
-      <button id="theme-toggle" type="button" aria-label="Toggle theme">
-        🌙
-      </button>
+      <span
+        id="theme-toggle"
+        role="button"
+        tabindex="0"
+        aria-label="Toggle theme"
+        >🌙</span
+      >
     </div>
 
     <div id="pool-section">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,12 @@
   </head>
 
   <body>
-    <h1>Cost Split Calculator</h1>
+    <div class="flex-row">
+      <h1>Cost Split Calculator</h1>
+      <button id="theme-toggle" type="button" aria-label="Toggle theme">
+        🌙
+      </button>
+    </div>
 
     <div id="pool-section">
       <label for="pool-name" class="hidden">Pool Name</label>

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,27 @@ import {
   savePoolToLocalStorage,
   startNewPool,
 } from "./share.js";
+import { initTheme, toggleTheme } from "./theme.js";
+
+/**
+ * Update the theme toggle button icon and accessible label.
+ *
+ * @param {"light"|"dark"} theme - Current theme.
+ * @returns {void}
+ */
+function updateThemeToggle(theme) {
+  const btn = document.getElementById("theme-toggle");
+  if (!btn) return;
+  if (theme === "dark") {
+    btn.textContent = "☀️";
+    btn.setAttribute("aria-label", "Switch to light mode");
+    btn.title = "Switch to light mode";
+  } else {
+    btn.textContent = "🌙";
+    btn.setAttribute("aria-label", "Switch to dark mode");
+    btn.title = "Switch to dark mode";
+  }
+}
 
 setAfterChange(() => {
   updateCurrentStateJson();
@@ -30,6 +51,8 @@ setAfterChange(() => {
 // initial load
 loadStateFromUrl();
 renderSavedPoolsTable();
+const theme = initTheme();
+updateThemeToggle(theme);
 
 // UI bindings
 document
@@ -71,6 +94,14 @@ document.getElementById("new-pool").addEventListener("click", () => {
   renderSavedPoolsTable();
 });
 
+const themeToggleBtn = document.getElementById("theme-toggle");
+if (themeToggleBtn)
+  themeToggleBtn.addEventListener("click", () => {
+    const newTheme = toggleTheme();
+    updateThemeToggle(newTheme);
+  });
+
 export * from "./state.js";
 export * from "./render.js";
 export * from "./share.js";
+export * from "./theme.js";

--- a/src/main.js
+++ b/src/main.js
@@ -23,22 +23,22 @@ import {
 import { initTheme, toggleTheme } from "./theme.js";
 
 /**
- * Update the theme toggle button icon and accessible label.
+ * Update the theme toggle icon and accessible label.
  *
  * @param {"light"|"dark"} theme - Current theme.
  * @returns {void}
  */
 function updateThemeToggle(theme) {
-  const btn = document.getElementById("theme-toggle");
-  if (!btn) return;
+  const icon = document.getElementById("theme-toggle");
+  if (!icon) return;
   if (theme === "dark") {
-    btn.textContent = "☀️";
-    btn.setAttribute("aria-label", "Switch to light mode");
-    btn.title = "Switch to light mode";
+    icon.textContent = "☀️";
+    icon.setAttribute("aria-label", "Switch to light mode");
+    icon.title = "Switch to light mode";
   } else {
-    btn.textContent = "🌙";
-    btn.setAttribute("aria-label", "Switch to dark mode");
-    btn.title = "Switch to dark mode";
+    icon.textContent = "🌙";
+    icon.setAttribute("aria-label", "Switch to dark mode");
+    icon.title = "Switch to dark mode";
   }
 }
 
@@ -94,12 +94,26 @@ document.getElementById("new-pool").addEventListener("click", () => {
   renderSavedPoolsTable();
 });
 
-const themeToggleBtn = document.getElementById("theme-toggle");
-if (themeToggleBtn)
-  themeToggleBtn.addEventListener("click", () => {
-    const newTheme = toggleTheme();
-    updateThemeToggle(newTheme);
+/**
+ * Toggle theme and update the icon.
+ *
+ * @returns {void}
+ */
+function onThemeToggle() {
+  const newTheme = toggleTheme();
+  updateThemeToggle(newTheme);
+}
+
+const themeToggleEl = document.getElementById("theme-toggle");
+if (themeToggleEl) {
+  themeToggleEl.addEventListener("click", onThemeToggle);
+  themeToggleEl.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onThemeToggle();
+    }
   });
+}
 
 export * from "./state.js";
 export * from "./render.js";

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,52 @@
+const THEME_KEY = "theme";
+
+/**
+ * Apply a theme to the document root.
+ *
+ * @param {"light"|"dark"} theme - Theme to apply.
+ * @returns {void}
+ */
+function applyTheme(theme) {
+  document.documentElement.dataset.theme = theme;
+}
+
+/**
+ * Initialize theme from local storage or system preference.
+ *
+ * @returns {"light"|"dark"} - The applied theme.
+ */
+function initTheme() {
+  let theme = "light";
+  try {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored === "light" || stored === "dark") {
+      theme = stored;
+    } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      theme = "dark";
+    }
+  } catch {
+    // ignore access errors
+  }
+  applyTheme(theme);
+  return theme;
+}
+
+/**
+ * Toggle between light and dark themes.
+ *
+ * @returns {"light"|"dark"} - The newly applied theme.
+ */
+function toggleTheme() {
+  const current =
+    document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+  const next = current === "dark" ? "light" : "dark";
+  applyTheme(next);
+  try {
+    localStorage.setItem(THEME_KEY, next);
+  } catch {
+    // ignore write errors
+  }
+  return next;
+}
+
+export { initTheme, toggleTheme };

--- a/styles.css
+++ b/styles.css
@@ -17,20 +17,18 @@
     Arial, sans-serif;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background-color: #121212;
-    --text-color: #eee;
-    --border-color: #555;
-    --muted-bg: #1e1e1e;
-    --alt-row-bg: #1a1a1a;
-    --primary-color: #569aff;
-    --danger-color: #ff7b72;
-    --warning-bg: #665c00;
-    --error-bg: rgba(255, 123, 114, 0.2);
-    --error-tooltip-bg: #3d1a1a;
-    --error-tooltip-color: #ff7b72;
-  }
+:root[data-theme="dark"] {
+  --background-color: #121212;
+  --text-color: #eee;
+  --border-color: #555;
+  --muted-bg: #1e1e1e;
+  --alt-row-bg: #1a1a1a;
+  --primary-color: #569aff;
+  --danger-color: #ff7b72;
+  --warning-bg: #665c00;
+  --error-bg: rgba(255, 123, 114, 0.2);
+  --error-tooltip-bg: #3d1a1a;
+  --error-tooltip-color: #ff7b72;
 }
 
 html {

--- a/styles.css
+++ b/styles.css
@@ -197,6 +197,17 @@ input[data-action="editItemSplit"] {
   margin: calc(var(--spacing) / 2) 0;
 }
 
+#theme-toggle {
+  cursor: pointer;
+  margin-left: auto;
+  font-size: 1.5rem;
+}
+
+#theme-toggle:focus {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
 .readonly-field {
   flex: 1;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- add persistent light/dark theme toggle
- use sun/moon icon button with accessible labels
- document theme toggle feature

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b240a8288320be0f1d89d28179a4