### PR TITLE
Improve pool reset and layout clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ groups. Try the live demo at
 - Responsive design that works on mobile and desktop
 - Light and dark themes with a sun/moon toggle that remembers your choice
 - Itemized transactions with proportional tax and tip
+- Non-itemized split fields are disabled when a transaction is itemized
 - Shareable URLs encoding the current calculator state
 - Optional session pool name to label each set of transactions
 - Save and load named pools using browser local storage with a table of saved

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ groups. Try the live demo at
 ## Features
 
 - Responsive design that works on mobile and desktop
-- Light and dark themes with a sun/moon toggle that remembers your choice
+- Light and dark themes with a toggle that shows the current theme and remembers
+  your choice
 - Itemized transactions with proportional tax and tip
 - Non-itemized split fields are disabled when a transaction is itemized
 - Unnamed transactions display numbered placeholders like "Transaction 4"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ groups. Try the live demo at
   a quick **New Pool** reset
 - Compact people list layout with clearly marked delete actions
 - Split sections show helpful messages when empty and flag unsaved pool changes
+- Summary totals prefix minus signs before dollar amounts for consistent
+  formatting
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ groups. Try the live demo at
 - Save and load named pools using browser local storage with a table of saved
   pools for quick loading or deletion, highlighting the active pool and offering
   a quick **New Pool** reset
+- Compact people list layout with clearly marked delete actions
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ groups. Try the live demo at
   pools for quick loading or deletion, highlighting the active pool and offering
   a quick **New Pool** reset
 - Compact people list layout with clearly marked delete actions
+- Split sections show helpful messages when empty and flag unsaved pool changes
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ groups. Try the live demo at
 - Light and dark themes with a sun/moon toggle that remembers your choice
 - Itemized transactions with proportional tax and tip
 - Non-itemized split fields are disabled when a transaction is itemized
+- Unnamed transactions display a "Transaction #" placeholder
 - Shareable URLs encoding the current calculator state
 - Optional session pool name to label each set of transactions
 - Save and load named pools using browser local storage with a table of saved

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ groups. Try the live demo at
 - Light and dark themes with a sun/moon toggle that remembers your choice
 - Itemized transactions with proportional tax and tip
 - Non-itemized split fields are disabled when a transaction is itemized
-- Unnamed transactions display a "Transaction #" placeholder
+- Unnamed transactions display numbered placeholders like "Transaction 4"
 - Shareable URLs encoding the current calculator state
 - Optional session pool name to label each set of transactions
 - Save and load named pools using browser local storage with a table of saved

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         role="button"
         tabindex="0"
         aria-label="Toggle theme"
-        >🌙</span
+        >☀️</span
       >
     </div>
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <div id="pool-section">
       <label for="pool-name" class="hidden">Pool Name</label>
       <input type="text" id="pool-name" placeholder="Pool name" />
+      <span id="pool-unsaved" class="unsaved-indicator"></span>
       <button id="new-pool" type="button">New Pool</button>
       <button id="save-local" type="button">Save Pool</button>
       <div class="table-container">

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import {
   downloadJson,
   savePoolToLocalStorage,
   startNewPool,
+  updatePoolSaveStatus,
 } from "./share.js";
 import { initTheme, toggleTheme } from "./theme.js";
 
@@ -46,6 +47,7 @@ setAfterChange(() => {
   updateCurrentStateJson();
   updateShareableUrl();
   calculateSummary();
+  updatePoolSaveStatus();
 });
 
 // initial load
@@ -59,6 +61,11 @@ document
   .getElementById("pool-name")
   .addEventListener("input", (e) => setPool(e.target.value));
 document.getElementById("save-people").addEventListener("click", addPerson);
+document.getElementById("person-name").addEventListener("keydown", (e) => {
+  if (e.key === "Enter") {
+    addPerson();
+  }
+});
 document
   .getElementById("download-json")
   .addEventListener("click", downloadJson);

--- a/src/main.js
+++ b/src/main.js
@@ -33,11 +33,11 @@ function updateThemeToggle(theme) {
   const icon = document.getElementById("theme-toggle");
   if (!icon) return;
   if (theme === "dark") {
-    icon.textContent = "☀️";
+    icon.textContent = "🌙";
     icon.setAttribute("aria-label", "Switch to light mode");
     icon.title = "Switch to light mode";
   } else {
-    icon.textContent = "🌙";
+    icon.textContent = "☀️";
     icon.setAttribute("aria-label", "Switch to dark mode");
     icon.title = "Switch to dark mode";
   }

--- a/src/render.js
+++ b/src/render.js
@@ -296,7 +296,8 @@ function createTransactionRow(t, i) {
   const nameCell = document.createElement("td");
   const nameInput = document.createElement("input");
   nameInput.type = "text";
-  nameInput.value = t.name || `Transaction ${i + 1}`;
+  nameInput.value = t.name || "";
+  nameInput.placeholder = `Transaction #${i + 1}`;
   nameInput.id = `transaction-name-${i}`;
   nameInput.setAttribute("aria-label", `Transaction ${i + 1} name`);
   nameInput.addEventListener("change", (e) =>
@@ -364,7 +365,7 @@ function createAddTransactionRow() {
   const addNameInput = document.createElement("input");
   addNameInput.type = "text";
   addNameInput.id = "new-t-name";
-  addNameInput.placeholder = "Name (optional)";
+  addNameInput.placeholder = `Transaction #${transactions.length + 1}`;
   addNameInput.setAttribute("aria-label", "New transaction name");
   addNameCell.appendChild(addNameInput);
   addRow.appendChild(addNameCell);
@@ -549,7 +550,7 @@ function renderSplitTable() {
       t.items.forEach((it, ii) => {
         const iRow = document.createElement("tr");
         const itemNameId = `item-name-${ti}-${ii}`;
-        let cell = `<td class="indent-cell"><input id="${itemNameId}" type="text" value="${it.item || ""}" placeholder="Item ${ii + 1}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="item" aria-label="Item ${ii + 1} name for ${tName}"></td>`;
+        let cell = `<td class="indent-cell"><input id="${itemNameId}" type="text" value="${it.item || ""}" placeholder="Item #${ii + 1}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="item" aria-label="Item ${ii + 1} name for ${tName}"></td>`;
         const itemCostId = `item-cost-${ti}-${ii}`;
         cell += `<td><div class="dollar-field"><span class="prefix">$</span><input id="${itemCostId}" type="text" value="${it.cost.toFixed(2)}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="cost" aria-label="Item ${ii + 1} cost for ${tName}"></div></td>`;
         people.forEach((p, pi) => {

--- a/src/render.js
+++ b/src/render.js
@@ -119,6 +119,7 @@ function renderSavedPoolsTable() {
       deletePoolFromLocalStorage(name);
       renderSavedPoolsTable();
     });
+    deleteBtn.classList.add("danger-btn");
     actionsCell.appendChild(deleteBtn);
     row.appendChild(actionsCell);
 
@@ -344,6 +345,7 @@ function createTransactionRow(t, i) {
   const delBtn = document.createElement("button");
   delBtn.textContent = "Delete";
   delBtn.addEventListener("click", () => deleteTransaction(i));
+  delBtn.classList.add("danger-btn");
   actionCell.appendChild(delBtn);
   row.appendChild(actionCell);
 
@@ -537,7 +539,7 @@ function renderSplitTable() {
       t.items.forEach((it, ii) => {
         const iRow = document.createElement("tr");
         const itemNameId = `item-name-${ti}-${ii}`;
-        let cell = `<td class="indent-cell"><input id="${itemNameId}" type="text" value="${it.item || ""}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="item" aria-label="Item ${ii + 1} name for ${tName}"></td>`;
+        let cell = `<td class="indent-cell"><input id="${itemNameId}" type="text" value="${it.item || ""}" placeholder="Item ${ii + 1}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="item" aria-label="Item ${ii + 1} name for ${tName}"></td>`;
         const itemCostId = `item-cost-${ti}-${ii}`;
         cell += `<td><div class="dollar-field"><span class="prefix">$</span><input id="${itemCostId}" type="text" value="${it.cost.toFixed(2)}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="cost" aria-label="Item ${ii + 1} cost for ${tName}"></div></td>`;
         people.forEach((p, pi) => {
@@ -640,7 +642,7 @@ function itemizeTransaction(ti) {
   const t = transactions[ti];
   t.items = [
     {
-      item: "Item 1",
+      item: "",
       cost: t.cost,
       splits: t.splits.slice(),
     },

--- a/src/render.js
+++ b/src/render.js
@@ -915,7 +915,15 @@ function calculateSummary() {
   html += `<tr><td><b>Total</b></td>
         <td><b>$${totalPaid.toFixed(2)}</b></td>
         <td><b>$${totalOwes.toFixed(2)}</b></td>
-        <td><b>$${totalNet.toFixed(2)}</b></td></tr>`;
+        <td><b>${
+          (totalNet > 0
+            ? "+"
+            : totalNet < 0 || Object.is(totalNet, -0)
+              ? "−"
+              : "") +
+          "$" +
+          Math.abs(totalNet).toFixed(2)
+        }</b></td></tr>`;
   html += "</table>";
   if (settlements.length > 0) {
     html += "<h3>Suggested Settlements</h3><ul>";

--- a/src/render.js
+++ b/src/render.js
@@ -297,7 +297,7 @@ function createTransactionRow(t, i) {
   const nameInput = document.createElement("input");
   nameInput.type = "text";
   nameInput.value = t.name || "";
-  nameInput.placeholder = `Transaction #${i + 1}`;
+  nameInput.placeholder = `Transaction ${i + 1}`;
   nameInput.id = `transaction-name-${i}`;
   nameInput.setAttribute("aria-label", `Transaction ${i + 1} name`);
   nameInput.addEventListener("change", (e) =>
@@ -365,7 +365,7 @@ function createAddTransactionRow() {
   const addNameInput = document.createElement("input");
   addNameInput.type = "text";
   addNameInput.id = "new-t-name";
-  addNameInput.placeholder = `Transaction #${transactions.length + 1}`;
+  addNameInput.placeholder = `Transaction ${transactions.length + 1}`;
   addNameInput.setAttribute("aria-label", "New transaction name");
   addNameCell.appendChild(addNameInput);
   addRow.appendChild(addNameCell);
@@ -550,7 +550,7 @@ function renderSplitTable() {
       t.items.forEach((it, ii) => {
         const iRow = document.createElement("tr");
         const itemNameId = `item-name-${ti}-${ii}`;
-        let cell = `<td class="indent-cell"><input id="${itemNameId}" type="text" value="${it.item || ""}" placeholder="Item #${ii + 1}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="item" aria-label="Item ${ii + 1} name for ${tName}"></td>`;
+        let cell = `<td class="indent-cell"><input id="${itemNameId}" type="text" value="${it.item || ""}" placeholder="Item ${ii + 1}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="item" aria-label="Item ${ii + 1} name for ${tName}"></td>`;
         const itemCostId = `item-cost-${ti}-${ii}`;
         cell += `<td><div class="dollar-field"><span class="prefix">$</span><input id="${itemCostId}" type="text" value="${it.cost.toFixed(2)}" data-action="editItem" data-ti="${ti}" data-ii="${ii}" data-field="cost" aria-label="Item ${ii + 1} cost for ${tName}"></div></td>`;
         people.forEach((p, pi) => {

--- a/src/render.js
+++ b/src/render.js
@@ -499,7 +499,16 @@ function deleteTransaction(i) {
 function renderSplitTable() {
   const splitDiv = document.getElementById("split-table");
   splitDiv.innerHTML = "";
-  if (transactions.length === 0 || people.length === 0) return;
+  if (people.length === 0) {
+    splitDiv.textContent = "Add people to begin splitting costs.";
+    renderSplitDetails();
+    return;
+  }
+  if (transactions.length === 0) {
+    splitDiv.textContent = "No transactions yet.";
+    renderSplitDetails();
+    return;
+  }
 
   const table = document.createElement("table");
   let header = "<tr><th>Name</th><th>Cost</th>";
@@ -511,6 +520,7 @@ function renderSplitTable() {
     const hasItems = Array.isArray(t.items);
     const collapsed = collapsedSplit.has(ti);
     const row = document.createElement("tr");
+    if (hasItems) row.classList.add("unused-row");
     const tName = t.name || `Transaction ${ti + 1}`;
     const arrow = hasItems ? (collapsed ? "▶" : "▼") : "";
     let cells = `<td>${
@@ -764,7 +774,13 @@ function toggleDetailItems(ti) {
 function renderSplitDetails() {
   const div = document.getElementById("split-details");
   div.innerHTML = "";
-  if (transactions.length === 0 || people.length === 0) return;
+  if (people.length === 0) {
+    return;
+  }
+  if (transactions.length === 0) {
+    div.textContent = "No split details yet.";
+    return;
+  }
 
   const table = document.createElement("table");
   const colSpan = people.length + 1;
@@ -875,17 +891,23 @@ function calculateSummary() {
     totalNet += net;
 
     const intensity = Math.abs(net) / maxAbs;
-    let bg = "white";
-    if (net > 0) bg = `rgba(0,255,0,${0.2 + 0.6 * intensity})`;
-    else if (net < 0) bg = `rgba(255,0,0,${0.2 + 0.6 * intensity})`;
+    let style = "";
+    if (net > 0) {
+      style = `background:rgba(0,255,0,${0.2 + 0.6 * intensity})`;
+    } else if (net < 0) {
+      style = `background:rgba(255,0,0,${0.2 + 0.6 * intensity})`;
+    }
 
     const netStr =
       (net > 0 ? "+" : net < 0 ? "−" : "") + "$" + Math.abs(net).toFixed(2);
+    const netCell = style
+      ? `<td style="${style}">${netStr}</td>`
+      : `<td>${netStr}</td>`;
     html += `<tr>
           <td>${p}</td>
           <td>$${paid[i].toFixed(2)}</td>
           <td>$${owes[i].toFixed(2)}</td>
-          <td style="background:${bg}">${netStr}</td>
+          ${netCell}
         </tr>`;
   });
 

--- a/src/share.js
+++ b/src/share.js
@@ -146,6 +146,12 @@ function applyLoadedState(state) {
   ) {
     renderSplitTable();
   }
+  if (
+    typeof renderSplitDetails === "function" &&
+    document.getElementById("split-details")
+  ) {
+    renderSplitDetails();
+  }
 
   const summaryEl = document.getElementById("summary");
   if (summaryEl) summaryEl.innerHTML = "";

--- a/src/share.js
+++ b/src/share.js
@@ -111,6 +111,37 @@ function updateShareableUrl() {
 }
 
 /**
+ * Indicate whether the current pool state has been saved.
+ */
+function updatePoolSaveStatus() {
+  const indicator = document.getElementById("pool-unsaved");
+  if (!indicator) return;
+  if (!pool) {
+    indicator.textContent = "";
+    return;
+  }
+  let saved = false;
+  if (typeof localStorage !== "undefined") {
+    try {
+      const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (raw) {
+        const pools = JSON.parse(raw);
+        const existing = pools && pools[pool];
+        if (existing) {
+          saved =
+            JSON.stringify(existing.people) === JSON.stringify(people) &&
+            JSON.stringify(existing.transactions) ===
+              JSON.stringify(transactions);
+        }
+      }
+    } catch (e) {
+      // ignore
+    }
+  }
+  indicator.textContent = saved ? "" : "Unsaved";
+}
+
+/**
  * Replace the current state with a loaded state and refresh the UI.
  *
  * @param {object} state - Parsed state object.
@@ -236,6 +267,7 @@ function savePoolToLocalStorage(name, { people: p, transactions: t }) {
   } catch (e) {
     // Fail silently; local storage may be unavailable or full.
   }
+  updatePoolSaveStatus();
 }
 
 /**
@@ -332,6 +364,7 @@ export {
   loadStateFromJsonFile,
   loadStateFromUrl,
   savePoolToLocalStorage,
+  updatePoolSaveStatus,
   loadPoolFromLocalStorage,
   listSavedPools,
   deletePoolFromLocalStorage,

--- a/styles.css
+++ b/styles.css
@@ -243,11 +243,20 @@ input[data-action="editItemSplit"] {
   cursor: pointer;
   margin-left: auto;
   font-size: 1.5rem;
+  padding: calc(var(--spacing) / 2);
+  border-radius: 0.25rem;
+  background-color: #121212;
+  color: #fff;
 }
 
 #theme-toggle:focus {
   outline: 2px solid var(--primary-color);
   outline-offset: 2px;
+}
+
+:root[data-theme="dark"] #theme-toggle {
+  background-color: #fff;
+  color: #000;
 }
 
 .readonly-field {

--- a/styles.css
+++ b/styles.css
@@ -40,6 +40,7 @@ body {
   max-width: 60rem;
   margin: 0 auto;
   padding: calc(var(--spacing) * 2.5);
+  padding-bottom: calc(var(--spacing) * 6);
   background-color: var(--background-color);
   color: var(--text-color);
 }
@@ -70,6 +71,10 @@ button {
   transition: filter 0.2s;
 }
 
+button + button {
+  margin-left: var(--spacing);
+}
+
 button:hover,
 button:focus {
   filter: brightness(0.9);
@@ -96,9 +101,14 @@ tbody tr:nth-child(even) {
   color: #fff;
 }
 
-#saved-pools-table tr.active-pool button {
+#saved-pools-table tr.active-pool button:not(.danger-btn) {
   background-color: #fff;
   color: var(--primary-color);
+}
+
+#saved-pools-table tr.active-pool button.danger-btn {
+  background-color: var(--danger-color);
+  color: #fff;
 }
 
 #transaction-table {
@@ -124,10 +134,29 @@ td:first-child {
   margin-left: calc(var(--spacing) / 2);
 }
 
+.danger-btn {
+  background-color: var(--danger-color);
+  color: #fff;
+}
+
 .collapse-btn {
   cursor: pointer;
   margin-right: calc(var(--spacing) / 2);
   font-weight: bold;
+}
+
+#people-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: calc(var(--spacing) / 2);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+#people-list li {
+  display: flex;
+  align-items: center;
 }
 
 .unused-row {

--- a/styles.css
+++ b/styles.css
@@ -163,6 +163,10 @@ td:first-child {
   background-color: var(--warning-bg);
 }
 
+.unused-row input {
+  text-decoration: line-through;
+}
+
 .invalid-cell {
   background-color: var(--error-bg);
 }
@@ -197,6 +201,12 @@ td:first-child {
 .error:focus::after {
   opacity: 1;
   pointer-events: auto;
+}
+
+.unsaved-indicator {
+  color: var(--danger-color);
+  margin-left: var(--spacing);
+  font-size: 0.9em;
 }
 
 .dollar-field {

--- a/styles.css
+++ b/styles.css
@@ -162,6 +162,12 @@ td:first-child {
 .unused-row input {
   background-color: var(--muted-bg);
   color: var(--border-color);
+  text-decoration: line-through;
+}
+
+:root[data-theme="dark"] .unused-row input {
+  background-color: #2a2a2a;
+  color: #888;
 }
 
 .invalid-cell {

--- a/styles.css
+++ b/styles.css
@@ -159,12 +159,9 @@ td:first-child {
   align-items: center;
 }
 
-.unused-row {
-  background-color: var(--warning-bg);
-}
-
 .unused-row input {
-  text-decoration: line-through;
+  background-color: var(--muted-bg);
+  color: var(--border-color);
 }
 
 .invalid-cell {

--- a/styles.css
+++ b/styles.css
@@ -245,7 +245,6 @@ input[data-action="editItemSplit"] {
   font-size: 1.5rem;
   padding: calc(var(--spacing) / 2);
   border-radius: 0.25rem;
-  background-color: #121212;
   color: #fff;
 }
 
@@ -255,7 +254,6 @@ input[data-action="editItemSplit"] {
 }
 
 :root[data-theme="dark"] #theme-toggle {
-  background-color: #fff;
   color: #000;
 }
 


### PR DESCRIPTION
## Summary
- Refresh split details when starting or loading a pool
- Style delete actions in red and tighten people list layout
- Add spacing and placeholders for itemized split controls

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5830ca6c88320a7100edfa131cff0