### PR TITLE
Clear state fields on page refresh

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -51,6 +51,7 @@ setAfterChange(() => {
 });
 
 // initial load
+startNewPool();
 loadStateFromUrl();
 renderSavedPoolsTable();
 const theme = initTheme();

--- a/src/share.js
+++ b/src/share.js
@@ -89,21 +89,34 @@ function validateState(state) {
 
 /**
  * Write the current state to the display input as JSON.
+ *
+ * Clears the display if no pool data exists.
  */
 function updateCurrentStateJson() {
   const display = document.getElementById("state-json-display");
+  if (!display) return;
+  if (!pool && people.length === 0 && transactions.length === 0) {
+    display.value = "";
+    return;
+  }
   const state = { pool, people, transactions };
-  if (display) display.value = JSON.stringify(state);
+  display.value = JSON.stringify(state);
 }
 
 /**
  * Update the share URL field with a link to the current state.
- * Uses the current page URL (including file:// URLs) as the base.
- * The state JSON is compressed with LZString to shorten the URL.
+ *
+ * Clears the field if there is no state to share. Otherwise uses the
+ * current page URL (including file:// URLs) as the base and appends a
+ * compressed representation of the state using LZString.
  */
 function updateShareableUrl() {
   const display = document.getElementById("share-url-display");
   if (!display || typeof window === "undefined") return;
+  if (!pool && people.length === 0 && transactions.length === 0) {
+    display.value = "";
+    return;
+  }
   const base = window.location.href.split(/[?#]/)[0];
   const json = JSON.stringify({ pool, people, transactions });
   const compressed = lz.compressToEncodedURIComponent(json);

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -433,16 +433,20 @@ describe("local storage helpers", () => {
     localStorage.clear();
   });
 
-  test("startNewPool resets state and clears pool name", () => {
+  test("startNewPool resets state and clears display fields", () => {
     people.push("Old");
     transactions.push({ payer: 0, cost: 1, splits: [1] });
     setPool("existing");
     document.getElementById("pool-name").value = "existing";
+    document.getElementById("state-json-display").value = "old";
+    document.getElementById("share-url-display").value = "old";
     startNewPool();
     expect(people).toEqual([]);
     expect(transactions).toEqual([]);
     expect(pool).toBe("");
     expect(document.getElementById("pool-name").value).toBe("");
+    expect(document.getElementById("state-json-display").value).toBe("");
+    expect(document.getElementById("share-url-display").value).toBe("");
   });
 
   test("save and load pool round trip", () => {


### PR DESCRIPTION
## Summary
- Clear JSON display and share URL when no pool data exists
- Reset pool UI fields by starting a new pool on page load
- Extend tests to ensure startNewPool wipes all display fields

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a21f3d1c83208fe63f8b0565910f