### PR TITLE
Improve suggested settlements formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ groups. Try the live demo at
 - Itemized and non-itemized transactions with proportional tax and tip
 - Shareable URLs and optional named session pools stored locally
 - Compact participant list with clear totals
+- Suggested settlements displayed in an easy-to-read table
 
 ## Usage
 

--- a/src/render.js
+++ b/src/render.js
@@ -870,7 +870,8 @@ function renderSplitDetails() {
 
 // ---- SUMMARY ----
 /**
- * Render a summary table of totals paid, owed and net for each person.
+ * Render a summary table of totals paid, owed and net for each person and a
+ * table of suggested settlements.
  */
 function calculateSummary() {
   const summaryEl = document.getElementById("summary");
@@ -926,13 +927,14 @@ function calculateSummary() {
         }</b></td></tr>`;
   html += "</table>";
   if (settlements.length > 0) {
-    html += "<h3>Suggested Settlements</h3><ul>";
+    html += "<h3>Suggested Settlements</h3>";
+    html += "<table><tr><th>Payer</th><th>Receiver</th><th>Amount</th></tr>";
     settlements.forEach((s) => {
-      html += `<li>${people[s.from]} pays ${people[s.to]} $${s.amount.toFixed(
+      html += `<tr><td>${people[s.from]}</td><td>${people[s.to]}</td><td>$${s.amount.toFixed(
         2,
-      )}</li>`;
+      )}</td></tr>`;
     });
-    html += "</ul>";
+    html += "</table>";
   }
 
   summaryEl.innerHTML = html;

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -121,9 +121,13 @@ describe("calculateSummary settlements", () => {
     people.push("Alice", "Bob");
     transactions.push({ payer: 0, cost: 30, splits: [1, 1] });
     calculateSummary();
-    expect(document.getElementById("summary").innerHTML).toContain(
-      "Bob pays Alice $15.00",
-    );
+    const settlementTable = document.querySelectorAll("#summary table")[1];
+    const cells = settlementTable
+      .querySelectorAll("tr")[1]
+      .querySelectorAll("td");
+    expect(cells[0].textContent).toBe("Bob");
+    expect(cells[1].textContent).toBe("Alice");
+    expect(cells[2].textContent).toBe("$15.00");
   });
 });
 


### PR DESCRIPTION
## Summary
- show settlement suggestions in a clear table with payer, receiver, and amount
- document summary rendering with settlement details
- update tests and docs for table-based settlements

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a65e8efc688320bd0d85982a05812a