### PR TITLE
Style person chips and unify item delete buttons

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -254,7 +254,11 @@ function renderPeople() {
     li.classList.add("person-bubble");
     const input = document.createElement("input");
     input.value = p;
-    input.oninput = () => clearError(input);
+    input.size = Math.max(p.length, 1);
+    input.addEventListener("input", () => {
+      clearError(input);
+      input.size = Math.max(input.value.length, 1);
+    });
     input.onblur = () => {
       if (!renamePerson(i, input.value)) {
         showError(input, "Name must be unique and non-empty.");

--- a/src/render.js
+++ b/src/render.js
@@ -251,6 +251,7 @@ function renderPeople() {
   list.innerHTML = "";
   people.forEach((p, i) => {
     const li = document.createElement("li");
+    li.classList.add("person-bubble");
     const input = document.createElement("input");
     input.value = p;
     input.oninput = () => clearError(input);
@@ -590,7 +591,7 @@ function renderSplitTable() {
           const aria = `Split for ${p} in item ${ii + 1} of ${tName}`;
           cell += `<td><input id="${splitId}" type="text" value="${val2}" data-action="editItemSplit" data-ti="${ti}" data-ii="${ii}" data-pi="${pi}" aria-label="${aria}"></td>`;
         });
-        cell += `<td><span class="delete-btn" data-action="deleteItem" data-ti="${ti}" data-ii="${ii}">❌</span></td>`;
+        cell += `<td><button class="danger-btn" data-action="deleteItem" data-ti="${ti}" data-ii="${ii}">Delete</button></td>`;
         iRow.innerHTML = cell;
         tbody.appendChild(iRow);
       });

--- a/styles.css
+++ b/styles.css
@@ -193,6 +193,28 @@ td:first-child {
   align-items: center;
 }
 
+.person-bubble {
+  background-color: var(--muted-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 9999px;
+  padding: 0 calc(var(--spacing) / 2);
+}
+
+.person-bubble input {
+  background: transparent;
+  border: none;
+  margin: 0;
+  padding: calc(var(--spacing) / 2) 0;
+}
+
+.person-bubble input:focus {
+  outline: none;
+}
+
+.person-bubble .delete-btn {
+  margin-left: calc(var(--spacing) / 4);
+}
+
 .unused-row input {
   background-color: var(--muted-bg);
   color: var(--border-color);

--- a/styles.css
+++ b/styles.css
@@ -205,6 +205,7 @@ td:first-child {
   border: none;
   margin: 0;
   padding: calc(var(--spacing) / 2) 0;
+  width: auto;
 }
 
 .person-bubble input:focus {
@@ -213,6 +214,7 @@ td:first-child {
 
 .person-bubble .delete-btn {
   margin-left: calc(var(--spacing) / 4);
+  font-size: 0.75rem;
 }
 
 .unused-row input {


### PR DESCRIPTION
## Summary
- Group each person's name and delete control in a rounded bubble
- Use standard danger button for deleting itemized cost split entries

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a828f2de988320a6717ba201b149dc