### PR TITLE
Expand item toggle hit area

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ groups. Try the live demo at
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAYgE6oDGALgJYQB2qsANONhFtvANogCCNdITAEKoiRAJ4CQAYWgjUIALpNyJGgGcyVWms6g66dgkQ4KRSqUrkJTUhDXl4ARgBMAZgB0ANgDsTMKjFsIicmNSxLHTgOAAZ3AFYGWNdE92cFAF8MoA)
    - **Shares** – assign share counts to weight the split.
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAgmKgE4Au62AdmSADTjYRbbwDaIBOy9IAQqgCWOAJ68AwgAsSggM4gAugzIlUVWagDGZQRHXtQVDKwQAlarQaaIs2nABMAFgDMAVgB0rhsRHYS8AEYGWSxBMnk4NiD7OmcFAF8EoA)
-   - **Itemized** – click the transaction name cell to expand and assign
-     specific items.
+   - **Itemized** – expand a transaction to assign specific items.
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAMgK4B2AxgBYgA042EW28A2iACKomo1LQCWPAGJ8IXEAF1aAFwBOnAM6oyUkSXktQXdEwTFyVWmQjyp8ACwB2AHQXaYVAE9sM+AAZa8rHynq4zAIzUgf6SIN7Y6L7MoOHo8CAAQkQyAObOPEYm8P4AzFY5tiCe-D4sge6u4gC+1DFSEfEAyqjQqAAmGcamcP7+VgBMABweXqV+7uXVtWH1cQgACqgm3IZd2WZWAKz9IyVRFUHVR1VAA)
 4. Use the **State** section to download or load a JSON file and the **Share**
    section to copy a link to the current state.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ groups. Try the live demo at
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAYgE6oDGALgJYQB2qsANONhFtvANogCCNdITAEKoiRAJ4CQAYWgjUIALpNyJGgGcyVWms6g66dgkQ4KRSqUrkJTUhDXl4ARgBMAZgB0ANgDsTMKjFsIicmNSxLHTgOAAZ3AFYGWNdE92cFAF8MoA)
    - **Shares** – assign share counts to weight the split.
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAgmKgE4Au62AdmSADTjYRbbwDaIBOy9IAQqgCWOAJ68AwgAsSggM4gAugzIlUVWagDGZQRHXtQVDKwQAlarQaaIs2nABMAFgDMAVgB0rhsRHYS8AEYGWSxBMnk4NiD7OmcFAF8EoA)
-   - **Itemized** – expand a transaction to assign specific items.
+   - **Itemized** – click the transaction name cell to expand and assign
+     specific items.
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAMgK4B2AxgBYgA042EW28A2iACKomo1LQCWPAGJ8IXEAF1aAFwBOnAM6oyUkSXktQXdEwTFyVWmQjyp8ACwB2AHQXaYVAE9sM+AAZa8rHynq4zAIzUgf6SIN7Y6L7MoOHo8CAAQkQyAObOPEYm8P4AzFY5tiCe-D4sge6u4gC+1DFSEfEAyqjQqAAmGcamcP7+VgBMABweXqV+7uXVtWH1cQgACqgm3IZd2WZWAKz9IyVRFUHVR1VAA)
 4. Use the **State** section to download or load a JSON file and the **Share**
    section to copy a link to the current state.

--- a/src/render.js
+++ b/src/render.js
@@ -552,12 +552,10 @@ function renderSplitTable() {
     row.classList.add(stripe);
     if (hasItems) row.classList.add("unused-row");
     const tName = t.name || `Transaction ${ti + 1}`;
-    const arrow = hasItems ? (collapsed ? "▶" : "▼") : "";
-    let cells = `<td>${
-      arrow
-        ? `<span class="collapse-btn" data-action="toggleSplitItems" data-ti="${ti}">${arrow}</span>`
-        : ""
-    }${tName}</td>`;
+    const arrow = hasItems ? (collapsed ? "▸" : "▾") : "";
+    let cells = `<td ${
+      arrow ? `data-action="toggleSplitItems" data-ti="${ti}"` : ""
+    }>${arrow ? `<span class="collapse-btn">${arrow}</span>` : ""}${tName}</td>`;
     cells += `<td>$${t.cost.toFixed(2)}</td>`;
     people.forEach((p, pi) => {
       const rawVal = t.splits[pi];
@@ -628,7 +626,8 @@ function renderSplitTable() {
   };
 
   table.onclick = (e) => {
-    const t = e.target;
+    const t = e.target.closest("[data-action]");
+    if (!t) return;
     const ti = parseInt(t.dataset.ti);
     switch (t.dataset.action) {
       case "toggleSplitItems":
@@ -836,12 +835,10 @@ function renderSplitDetails() {
     const row = document.createElement("tr");
     const stripe = rowClass(rowIdx);
     row.classList.add(stripe);
-    const arrow = hasItems ? (collapsed ? "▶" : "▼") : "";
-    let cells = `<td>${
-      arrow
-        ? `<span class="collapse-btn" data-action="toggleDetailItems" data-ti="${ti}">${arrow}</span>`
-        : ""
-    }${tName} - $${t.cost.toFixed(2)}</td>`;
+    const arrow = hasItems ? (collapsed ? "▸" : "▾") : "";
+    let cells = `<td ${
+      arrow ? `data-action="toggleDetailItems" data-ti="${ti}"` : ""
+    }>${arrow ? `<span class="collapse-btn">${arrow}</span>` : ""}${tName} - $${t.cost.toFixed(2)}</td>`;
     const personTotals = Array(people.length).fill(0);
     if (hasItems) {
       const itemsTotal = t.items.reduce((sum, it) => sum + it.cost, 0);
@@ -901,8 +898,9 @@ function renderSplitDetails() {
   tbody.appendChild(totalRow);
 
   table.onclick = (e) => {
-    if (e.target.dataset.action === "toggleDetailItems") {
-      toggleDetailItems(parseInt(e.target.dataset.ti));
+    const target = e.target.closest("[data-action]");
+    if (target && target.dataset.action === "toggleDetailItems") {
+      toggleDetailItems(parseInt(target.dataset.ti));
     }
   };
 

--- a/styles.css
+++ b/styles.css
@@ -174,9 +174,17 @@ td:first-child {
 }
 
 .collapse-btn {
-  cursor: pointer;
   margin-right: calc(var(--spacing) / 2);
   font-weight: bold;
+  display: inline-block;
+  width: 1em;
+  text-align: center;
+  font-size: 0.9em;
+}
+
+td[data-action="toggleSplitItems"],
+td[data-action="toggleDetailItems"] {
+  cursor: pointer;
 }
 
 #people-list {


### PR DESCRIPTION
## Summary
- Let users click the full transaction or detail cell to collapse/expand itemized rows
- Use uniform small triangles for expand/collapse icons and normalize icon sizing
- Document how to expand itemized transactions

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a829e8cf188320a7c15fffa171e2cc