### PR TITLE
feat: warn on unsaved pool changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ groups. Try the live demo at
 - Tables outlined with subtle borders and rounded corners for a softer look
 - Itemized and non-itemized transactions with proportional tax and tip
 - Shareable URLs and optional named session pools stored locally
+- Warns before discarding unsaved changes when switching pools
 - Compact participant list with clear totals
 - External footer links open in new tabs with security safeguards
 

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import {
   downloadJson,
   savePoolToLocalStorage,
   startNewPool,
+  hasUnsavedChanges,
   updatePoolSaveStatus,
 } from "./share.js";
 
@@ -75,6 +76,9 @@ document.getElementById("save-local").addEventListener("click", () => {
 });
 
 document.getElementById("new-pool").addEventListener("click", () => {
+  if (hasUnsavedChanges() && !confirm("You have unsaved changes. Continue?")) {
+    return;
+  }
   startNewPool();
   renderSavedPoolsTable();
 });

--- a/src/render.js
+++ b/src/render.js
@@ -14,6 +14,7 @@ import {
   loadPoolFromLocalStorage,
   deletePoolFromLocalStorage,
   LOCAL_STORAGE_KEY,
+  hasUnsavedChanges,
 } from "./share.js";
 
 const COST_FORMAT_MSG =
@@ -137,6 +138,12 @@ function renderSavedPoolsTable() {
       row.classList.add("active-pool");
     }
     row.addEventListener("click", () => {
+      if (
+        hasUnsavedChanges() &&
+        !confirm("You have unsaved changes. Continue?")
+      ) {
+        return;
+      }
       loadPoolFromLocalStorage(name);
       renderSavedPoolsTable();
     });

--- a/src/share.js
+++ b/src/share.js
@@ -124,6 +124,30 @@ function updateShareableUrl() {
 }
 
 /**
+ * Check whether the current pool state differs from the saved version.
+ *
+ * @returns {boolean} True if there are unsaved changes.
+ */
+function hasUnsavedChanges() {
+  if (!pool && people.length === 0 && transactions.length === 0) return false;
+  if (!pool) return true;
+  if (typeof localStorage === "undefined") return true;
+  try {
+    const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (!raw) return true;
+    const pools = JSON.parse(raw);
+    const existing = pools && pools[pool];
+    if (!existing) return true;
+    return (
+      JSON.stringify(existing.people) !== JSON.stringify(people) ||
+      JSON.stringify(existing.transactions) !== JSON.stringify(transactions)
+    );
+  } catch (e) {
+    return true;
+  }
+}
+
+/**
  * Indicate whether the current pool state has been saved.
  */
 function updatePoolSaveStatus() {
@@ -133,25 +157,7 @@ function updatePoolSaveStatus() {
     indicator.textContent = "";
     return;
   }
-  let saved = false;
-  if (typeof localStorage !== "undefined") {
-    try {
-      const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
-      if (raw) {
-        const pools = JSON.parse(raw);
-        const existing = pools && pools[pool];
-        if (existing) {
-          saved =
-            JSON.stringify(existing.people) === JSON.stringify(people) &&
-            JSON.stringify(existing.transactions) ===
-              JSON.stringify(transactions);
-        }
-      }
-    } catch (e) {
-      // ignore
-    }
-  }
-  indicator.textContent = saved ? "" : "Unsaved";
+  indicator.textContent = hasUnsavedChanges() ? "Unsaved" : "";
 }
 
 /**
@@ -377,6 +383,7 @@ export {
   loadStateFromJsonFile,
   loadStateFromUrl,
   savePoolToLocalStorage,
+  hasUnsavedChanges,
   updatePoolSaveStatus,
   loadPoolFromLocalStorage,
   listSavedPools,


### PR DESCRIPTION
## Summary
- prompt before discarding unsaved changes when starting a new pool
- confirm unsaved changes before loading a different saved pool
- document unsaved warning in README

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a82a66db008320a0f5060f19f70777