### PR TITLE
Add transaction and settlement filters

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -178,3 +178,49 @@ export function resetState() {
   pool = "";
   afterChange();
 }
+
+/**
+ * Get all transactions paid by a specific person.
+ *
+ * @param {number} index - Index of the person in the {@link people} array.
+ * @returns {typeof transactions} A list of transactions where the person was the payer.
+ */
+export function getTransactionsPaidBy(index) {
+  return transactions.filter((t) => t.payer === index);
+}
+
+/**
+ * Get transactions that involve a specific person either as payer or participant.
+ *
+ * A transaction is considered involving the person if they paid for it or if they
+ * are included in the split of the transaction or any of its itemized sub-splits.
+ *
+ * @param {number} index - Index of the person in the {@link people} array.
+ * @returns {typeof transactions} A list of transactions involving the person.
+ */
+export function getTransactionsInvolving(index) {
+  return transactions.filter((t) => {
+    if (t.payer === index) return true;
+    if (t.splits[index] > 0) return true;
+    if (Array.isArray(t.items)) {
+      return t.items.some((it) => it.splits[index] > 0);
+    }
+    return false;
+  });
+}
+
+/**
+ * Compute settlement suggestions that involve a specific person.
+ *
+ * This uses {@link computeSettlements} to determine all settlements for the
+ * current state and then filters the result for settlements where the person is
+ * either the payer or the receiver.
+ *
+ * @param {number} index - Index of the person in the {@link people} array.
+ * @returns {Array<{from:number,to:number,amount:number}>} Settlements involving the person.
+ */
+export function getSettlementsFor(index) {
+  return computeSettlements(people, transactions).filter(
+    (s) => s.from === index || s.to === index,
+  );
+}

--- a/tests/stateHelpers.test.js
+++ b/tests/stateHelpers.test.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  resetState,
+  people,
+  transactions,
+  getTransactionsPaidBy,
+  getTransactionsInvolving,
+  getSettlementsFor,
+} from "../src/state.js";
+
+describe("state helper filters", () => {
+  beforeEach(() => {
+    resetState();
+    people.push("A", "B", "C");
+  });
+
+  test("getTransactionsPaidBy returns only matching payer", () => {
+    transactions.push(
+      { payer: 0, cost: 10, splits: [1, 1, 0] },
+      { payer: 1, cost: 20, splits: [0, 1, 1] },
+    );
+    expect(getTransactionsPaidBy(1)).toEqual([
+      { payer: 1, cost: 20, splits: [0, 1, 1] },
+    ]);
+  });
+
+  test("getTransactionsInvolving detects splits and items", () => {
+    transactions.push(
+      { payer: 0, cost: 10, splits: [1, 0, 0] },
+      { payer: 1, cost: 5, splits: [0, 1, 0] },
+      {
+        payer: 0,
+        cost: 5,
+        splits: [0, 0, 0],
+        items: [{ cost: 5, splits: [0, 1, 0] }],
+      },
+    );
+    expect(getTransactionsInvolving(1)).toEqual([
+      { payer: 1, cost: 5, splits: [0, 1, 0] },
+      {
+        payer: 0,
+        cost: 5,
+        splits: [0, 0, 0],
+        items: [{ cost: 5, splits: [0, 1, 0] }],
+      },
+    ]);
+  });
+
+  test("getSettlementsFor filters settlement list", () => {
+    transactions.push({ payer: 0, cost: 30, splits: [1, 1, 0] });
+    expect(getSettlementsFor(1)).toEqual([{ from: 1, to: 0, amount: 15 }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add helper functions to filter transactions and settlements per participant
- test filtering helpers for transactions and settlements

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8a26b92b88320a193a43022ef560a