### PR TITLE
Enable per-person view from summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ groups. Try the live demo at
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAMgK4B2AxgBYgA042EW28A2iACKomo1LQCWPAGJ8IXEAF1aAFwBOnAM6oyUkSXktQXdEwTFyVWmQjyp8ACwB2AHQXaYVAE9sM+AAZa8rHynq4zAIzUgf6SIN7Y6L7MoOHo8CAAQkQyAObOPEYm8P4AzFY5tiCe-D4sge6u4gC+1DFSEfEAyqjQqAAmGcamcP7+VgBMABweXqV+7uXVtWH1cQgACqgm3IZd2WZWAKz9IyVRFUHVR1VAA)
 4. In the **View Summary** section, review totals. Click a person's name to see
    their "[Name] summary" below the table, separated by a horizontal rule. The
-   Transactions and Cost Splits sections highlight rows and cells involving the
-   selected person, and split details emphasize their non-zero contributions.
-   Any section with no data will show a friendly note instead. Use **Close** to
-   hide the personal view and remove highlights.
+   Transactions section highlights only rows they paid for, Cost Splits and
+   split details emphasize their non-zero contributions, and each table ends
+   with a total row for quick reference. Any section with no data will show a
+   friendly note instead. Use **Close** to hide the personal view and remove
+   highlights.
 5. Use the **State** section to download or load a JSON file and the **Share**
    section to copy a link to the current state.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ groups. Try the live demo at
 - Warns before discarding unsaved changes when switching pools
 - Compact participant list with clear totals
 - External footer links open in new tabs with security safeguards
-- Click a name in the summary to expand their transactions, personal shares, and
-  a highlighted settlement plan beneath the table
+- Click a name in the summary to expand an "[Name] summary" showing their
+  transactions, personal shares, and a highlighted settlement plan beneath the
+  table. If they haven't paid or split any costs, a note appears instead of an
+  empty section.
 
 ## Usage
 
@@ -37,8 +39,10 @@ groups. Try the live demo at
    - **Itemized** – expand a transaction to assign specific items.
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAMgK4B2AxgBYgA042EW28A2iACKomo1LQCWPAGJ8IXEAF1aAFwBOnAM6oyUkSXktQXdEwTFyVWmQjyp8ACwB2AHQXaYVAE9sM+AAZa8rHynq4zAIzUgf6SIN7Y6L7MoOHo8CAAQkQyAObOPEYm8P4AzFY5tiCe-D4sge6u4gC+1DFSEfEAyqjQqAAmGcamcP7+VgBMABweXqV+7uXVtWH1cQgACqgm3IZd2WZWAKz9IyVRFUHVR1VAA)
 4. In the **View Summary** section, review totals. Click a person's name to see
-   their transactions, what they owe for shared splits, and a highlighted
-   settlement plan beneath the summary. Use **Close** to hide the personal view.
+   their "[Name] summary" with transactions they paid, what they owe for shared
+   splits, and a highlighted settlement plan beneath the summary. Any section
+   with no data will show a friendly note instead. Use **Close** to hide the
+   personal view.
 5. Use the **State** section to download or load a JSON file and the **Share**
    section to copy a link to the current state.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ groups. Try the live demo at
 - Warns before discarding unsaved changes when switching pools
 - Compact participant list with clear totals
 - External footer links open in new tabs with security safeguards
-- Click a name in the summary to view their transactions and settlements
+- Click a name in the summary to view their transactions, personal shares, and
+  highlighted settlement plan
 
 ## Usage
 
@@ -36,8 +37,8 @@ groups. Try the live demo at
    - **Itemized** – expand a transaction to assign specific items.
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAMgK4B2AxgBYgA042EW28A2iACKomo1LQCWPAGJ8IXEAF1aAFwBOnAM6oyUkSXktQXdEwTFyVWmQjyp8ACwB2AHQXaYVAE9sM+AAZa8rHynq4zAIzUgf6SIN7Y6L7MoOHo8CAAQkQyAObOPEYm8P4AzFY5tiCe-D4sge6u4gC+1DFSEfEAyqjQqAAmGcamcP7+VgBMABweXqV+7uXVtWH1cQgACqgm3IZd2WZWAKz9IyVRFUHVR1VAA)
 4. In the **View Summary** section, review totals. Click a person's name to see
-   their transactions and settlement plan, then use **Back to Summary** to
-   return.
+   their transactions, what they owe for shared splits, and a highlighted
+   settlement plan. Use **Back to Summary** to return.
 5. Use the **State** section to download or load a JSON file and the **Share**
    section to copy a link to the current state.
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ groups. Try the live demo at
 - Warns before discarding unsaved changes when switching pools
 - Compact participant list with clear totals
 - External footer links open in new tabs with security safeguards
-- Click a name in the summary to view their transactions, personal shares, and
-  highlighted settlement plan
+- Click a name in the summary to expand their transactions, personal shares, and
+  a highlighted settlement plan beneath the table
 
 ## Usage
 
@@ -38,7 +38,7 @@ groups. Try the live demo at
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAMgK4B2AxgBYgA042EW28A2iACKomo1LQCWPAGJ8IXEAF1aAFwBOnAM6oyUkSXktQXdEwTFyVWmQjyp8ACwB2AHQXaYVAE9sM+AAZa8rHynq4zAIzUgf6SIN7Y6L7MoOHo8CAAQkQyAObOPEYm8P4AzFY5tiCe-D4sge6u4gC+1DFSEfEAyqjQqAAmGcamcP7+VgBMABweXqV+7uXVtWH1cQgACqgm3IZd2WZWAKz9IyVRFUHVR1VAA)
 4. In the **View Summary** section, review totals. Click a person's name to see
    their transactions, what they owe for shared splits, and a highlighted
-   settlement plan. Use **Back to Summary** to return.
+   settlement plan beneath the summary. Use **Close** to hide the personal view.
 5. Use the **State** section to download or load a JSON file and the **Share**
    section to copy a link to the current state.
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ groups. Try the live demo at
 - Warns before discarding unsaved changes when switching pools
 - Compact participant list with clear totals
 - External footer links open in new tabs with security safeguards
-- Click a name in the summary to expand an "[Name] summary" showing their
-  transactions, personal shares, and a highlighted settlement plan beneath the
-  table. If they haven't paid or split any costs, a note appears instead of an
-  empty section.
+- Click a name in the summary to expand an "[Name] summary" beneath the table
+  and a divider. The view highlights their transactions, split cells, and
+  non-zero contributions in split details, with a settlement plan. If they
+  haven't paid or split any costs, a note appears instead of an empty section.
 
 ## Usage
 
@@ -39,10 +39,11 @@ groups. Try the live demo at
    - **Itemized** – expand a transaction to assign specific items.
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAMgK4B2AxgBYgA042EW28A2iACKomo1LQCWPAGJ8IXEAF1aAFwBOnAM6oyUkSXktQXdEwTFyVWmQjyp8ACwB2AHQXaYVAE9sM+AAZa8rHynq4zAIzUgf6SIN7Y6L7MoOHo8CAAQkQyAObOPEYm8P4AzFY5tiCe-D4sge6u4gC+1DFSEfEAyqjQqAAmGcamcP7+VgBMABweXqV+7uXVtWH1cQgACqgm3IZd2WZWAKz9IyVRFUHVR1VAA)
 4. In the **View Summary** section, review totals. Click a person's name to see
-   their "[Name] summary" with transactions they paid, what they owe for shared
-   splits, and a highlighted settlement plan beneath the summary. Any section
-   with no data will show a friendly note instead. Use **Close** to hide the
-   personal view.
+   their "[Name] summary" below the table, separated by a horizontal rule. The
+   Transactions and Cost Splits sections highlight rows and cells involving the
+   selected person, and split details emphasize their non-zero contributions.
+   Any section with no data will show a friendly note instead. Use **Close** to
+   hide the personal view and remove highlights.
 5. Use the **State** section to download or load a JSON file and the **Share**
    section to copy a link to the current state.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ groups. Try the live demo at
 - Warns before discarding unsaved changes when switching pools
 - Compact participant list with clear totals
 - External footer links open in new tabs with security safeguards
+- Click a name in the summary to view their transactions and settlements
 
 ## Usage
 
@@ -34,7 +35,10 @@ groups. Try the live demo at
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAgmKgE4Au62AdmSADTjYRbbwDaIBOy9IAQqgCWOAJ68AwgAsSggM4gAugzIlUVWagDGZQRHXtQVDKwQAlarQaaIs2nABMAFgDMAVgB0rhsRHYS8AEYGWSxBMnk4NiD7OmcFAF8EoA)
    - **Itemized** – expand a transaction to assign specific items.
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAMgK4B2AxgBYgA042EW28A2iACKomo1LQCWPAGJ8IXEAF1aAFwBOnAM6oyUkSXktQXdEwTFyVWmQjyp8ACwB2AHQXaYVAE9sM+AAZa8rHynq4zAIzUgf6SIN7Y6L7MoOHo8CAAQkQyAObOPEYm8P4AzFY5tiCe-D4sge6u4gC+1DFSEfEAyqjQqAAmGcamcP7+VgBMABweXqV+7uXVtWH1cQgACqgm3IZd2WZWAKz9IyVRFUHVR1VAA)
-4. Use the **State** section to download or load a JSON file and the **Share**
+4. In the **View Summary** section, review totals. Click a person's name to see
+   their transactions and settlement plan, then use **Back to Summary** to
+   return.
+5. Use the **State** section to download or load a JSON file and the **Share**
    section to copy a link to the current state.
 
 ## Examples

--- a/src/render.js
+++ b/src/render.js
@@ -963,6 +963,8 @@ function calculateSummary() {
     const row = document.createElement("tr");
     const personCell = document.createElement("td");
     personCell.textContent = p;
+    personCell.classList.add("person-link");
+    personCell.addEventListener("click", () => showPersonSummary(i));
     row.appendChild(personCell);
 
     const paidCell = document.createElement("td");
@@ -1016,6 +1018,27 @@ function calculateSummary() {
     });
     summaryEl.appendChild(ul);
   }
+}
+
+/**
+ * Show detailed information for a single person and hide the global summary.
+ *
+ * Creates a temporary view with a back button that restores the original
+ * summary table.
+ *
+ * @param {number} index - Index of the person in the {@link people} array.
+ * @returns {void}
+ */
+function showPersonSummary(index) {
+  const summaryEl = document.getElementById("summary");
+  if (!summaryEl) return;
+  summaryEl.innerHTML = "";
+
+  const backBtn = document.createElement("button");
+  backBtn.textContent = "Back to Summary";
+  backBtn.addEventListener("click", calculateSummary);
+  summaryEl.appendChild(backBtn);
+  summaryEl.appendChild(renderPersonView(index));
 }
 
 /**

--- a/src/render.js
+++ b/src/render.js
@@ -1022,10 +1022,11 @@ function calculateSummary() {
 }
 
 /**
- * Show detailed information for a single person and hide the global summary.
+ * Show detailed information for a single person below the summary.
  *
- * Creates a temporary view with a back button that restores the original
- * summary table.
+ * Appends a person-specific view after the global summary table along with a
+ * Close button to remove it. Any previously displayed person view is replaced
+ * with the new selection.
  *
  * @param {number} index - Index of the person in the {@link people} array.
  * @returns {void}
@@ -1033,13 +1034,20 @@ function calculateSummary() {
 function showPersonSummary(index) {
   const summaryEl = document.getElementById("summary");
   if (!summaryEl) return;
-  summaryEl.innerHTML = "";
 
-  const backBtn = document.createElement("button");
-  backBtn.textContent = "Back to Summary";
-  backBtn.addEventListener("click", calculateSummary);
-  summaryEl.appendChild(backBtn);
-  summaryEl.appendChild(renderPersonView(index));
+  const existing = document.getElementById("person-summary");
+  if (existing) existing.remove();
+
+  const container = document.createElement("div");
+  container.id = "person-summary";
+
+  const closeBtn = document.createElement("button");
+  closeBtn.textContent = "Close";
+  closeBtn.addEventListener("click", () => container.remove());
+  container.appendChild(closeBtn);
+
+  container.appendChild(renderPersonView(index));
+  summaryEl.appendChild(container);
 }
 
 /**
@@ -1214,4 +1222,5 @@ export {
   calculateSummary,
   renderSavedPoolsTable,
   renderPersonView,
+  showPersonSummary,
 };

--- a/src/render.js
+++ b/src/render.js
@@ -986,6 +986,7 @@ function calculateSummary() {
   });
 
   const totalRow = document.createElement("tr");
+  totalRow.classList.add("total-row");
   totalRow.innerHTML = `<td><b>Total</b></td>
         <td><b>$${totalPaid.toFixed(2)}</b></td>
         <td><b>$${totalOwes.toFixed(2)}</b></td>
@@ -1098,11 +1099,7 @@ function showPersonSummary(index) {
   txRows.forEach((row, ti) => {
     if (ti >= transactions.length) return;
     const t = transactions[ti];
-    const involved =
-      t.payer === index ||
-      t.splits[index] > 0 ||
-      (Array.isArray(t.items) && t.items.some((it) => it.splits[index] > 0));
-    if (involved) row.classList.add("person-highlight");
+    if (t.payer === index) row.classList.add("person-highlight");
   });
 
   document
@@ -1131,7 +1128,7 @@ function showPersonSummary(index) {
  * @param {typeof transactions} txns - Transactions to display.
  * @param {number} [personIndex] - Person index to show individual shares for.
  * @param {number} [highlightIndex] - Person index whose payer cells should be highlighted.
- * @returns {HTMLTableElement} Table element with transaction details.
+ * @returns {HTMLTableElement} Table element with transaction details and a total row.
  */
 function buildTransactionsTable(txns, personIndex, highlightIndex) {
   const table = document.createElement("table");
@@ -1147,6 +1144,7 @@ function buildTransactionsTable(txns, personIndex, highlightIndex) {
   table.appendChild(thead);
 
   const tbody = document.createElement("tbody");
+  let total = 0;
   txns.forEach((t) => {
     const row = document.createElement("tr");
 
@@ -1169,9 +1167,17 @@ function buildTransactionsTable(txns, personIndex, highlightIndex) {
     }
     costCell.textContent = `$${cost.toFixed(2)}`;
     row.appendChild(costCell);
+    total += cost;
 
     tbody.appendChild(row);
   });
+
+  const totalRow = document.createElement("tr");
+  totalRow.classList.add("total-row");
+  totalRow.innerHTML =
+    "<td><b>Total</b></td><td></td><td><b>$" + total.toFixed(2) + "</b></td>";
+  tbody.appendChild(totalRow);
+
   table.appendChild(tbody);
   return table;
 }
@@ -1181,7 +1187,7 @@ function buildTransactionsTable(txns, personIndex, highlightIndex) {
  *
  * @param {Array<{from:number,to:number,amount:number}>} settlements - Suggested settlements.
  * @param {number} [personIndex] - Person index to highlight within the table.
- * @returns {HTMLTableElement} Table element with settlement details.
+ * @returns {HTMLTableElement} Table element with settlement details and a total row.
  */
 function buildSettlementTable(settlements, personIndex) {
   const table = document.createElement("table");
@@ -1196,6 +1202,7 @@ function buildSettlementTable(settlements, personIndex) {
   table.appendChild(thead);
 
   const tbody = document.createElement("tbody");
+  let total = 0;
   settlements.forEach((s) => {
     const row = document.createElement("tr");
 
@@ -1216,9 +1223,17 @@ function buildSettlementTable(settlements, personIndex) {
     const amountCell = document.createElement("td");
     amountCell.textContent = `$${s.amount.toFixed(2)}`;
     row.appendChild(amountCell);
+    total += s.amount;
 
     tbody.appendChild(row);
   });
+
+  const totalRow = document.createElement("tr");
+  totalRow.classList.add("total-row");
+  totalRow.innerHTML =
+    "<td><b>Total</b></td><td></td><td><b>$" + total.toFixed(2) + "</b></td>";
+  tbody.appendChild(totalRow);
+
   table.appendChild(tbody);
   return table;
 }

--- a/styles.css
+++ b/styles.css
@@ -167,7 +167,9 @@ td:first-child {
   text-decoration: underline;
 }
 
-.settlement-person {
+.settlement-person,
+td.person-highlight,
+tr.person-highlight > td {
   background-color: var(--warning-bg);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -114,6 +114,11 @@ td {
   border-bottom: 1px solid var(--border-color);
 }
 
+.total-row td {
+  border-top: 3px solid var(--border-color);
+  padding-top: calc(var(--spacing) * 1.5);
+}
+
 tbody tr {
   background-color: var(--section-bg);
 }

--- a/styles.css
+++ b/styles.css
@@ -162,6 +162,11 @@ td:first-child {
   text-align: left;
 }
 
+.person-link {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 .delete-btn {
   cursor: pointer;
   color: var(--danger-color);

--- a/styles.css
+++ b/styles.css
@@ -167,6 +167,10 @@ td:first-child {
   text-decoration: underline;
 }
 
+.settlement-person {
+  background-color: var(--warning-bg);
+}
+
 .delete-btn {
   cursor: pointer;
   color: var(--danger-color);

--- a/tests/personView.test.js
+++ b/tests/personView.test.js
@@ -18,7 +18,7 @@ describe("person view helpers", () => {
     );
   });
 
-  test("renderPersonView builds sections for paid, shared and settlement", () => {
+  test("renderPersonView builds sections and highlights person", () => {
     const view = renderPersonView(0);
     const tables = view.querySelectorAll("table");
     expect(tables.length).toBe(3);
@@ -26,11 +26,26 @@ describe("person view helpers", () => {
     const paidRows = tables[0].querySelectorAll("tbody tr");
     expect(paidRows.length).toBe(1);
     expect(paidRows[0].children[0].textContent).toBe("T1");
+    expect(paidRows[0].children[1].classList.contains("person-highlight")).toBe(
+      true,
+    );
 
     const sharedRows = tables[1].querySelectorAll("tbody tr");
     expect(sharedRows.length).toBe(2);
     expect(sharedRows[0].children[2].textContent).toBe("$5.00");
     expect(sharedRows[1].children[2].textContent).toBe("$10.00");
+    expect(
+      sharedRows[0].children[1].classList.contains("person-highlight"),
+    ).toBe(true);
+    expect(
+      sharedRows[1].children[1].classList.contains("person-highlight"),
+    ).toBe(false);
+    expect(
+      sharedRows[0].children[2].classList.contains("person-highlight"),
+    ).toBe(true);
+    expect(
+      sharedRows[1].children[2].classList.contains("person-highlight"),
+    ).toBe(true);
 
     const settlementRows = tables[2].querySelectorAll("tbody tr");
     expect(settlementRows.length).toBe(1);
@@ -45,6 +60,16 @@ describe("person view helpers", () => {
     expect(settlementRows[0].children[2].textContent).toBe("$5.00");
   });
 
+  test("renderPersonView handles missing transactions and splits", () => {
+    resetState();
+    people.push("A");
+    const view = renderPersonView(0);
+    expect(view.querySelector("table")).toBeNull();
+    expect(view.textContent).toContain("A didn't pay for any transactions.");
+    expect(view.textContent).toContain("A wasn't involved in any cost splits.");
+    expect(view.textContent).toContain("A has no settlements.");
+  });
+
   test("showPersonSummary appends view below summary and closes", () => {
     document.body.innerHTML = '<div id="summary"></div>';
     calculateSummary();
@@ -53,11 +78,21 @@ describe("person view helpers", () => {
     const summaryTable = document.querySelector("#summary > table");
     expect(summaryTable).not.toBeNull();
 
+    const highlighted = summaryTable
+      ?.querySelectorAll("tbody tr")[0]
+      .classList.contains("person-highlight");
+    expect(highlighted).toBe(true);
+
     const personDiv = document.getElementById("person-summary");
     expect(personDiv).not.toBeNull();
+    expect(personDiv.querySelector("h3")?.textContent).toBe("A summary");
     expect(personDiv.querySelectorAll("table").length).toBe(3);
 
     personDiv.querySelector("button")?.click();
     expect(document.getElementById("person-summary")).toBeNull();
+    const cleared = summaryTable
+      ?.querySelectorAll("tbody tr")[0]
+      .classList.contains("person-highlight");
+    expect(cleared).toBe(false);
   });
 });

--- a/tests/personView.test.js
+++ b/tests/personView.test.js
@@ -26,14 +26,16 @@ describe("person view helpers", () => {
     expect(tables.length).toBe(3);
 
     const paidRows = tables[0].querySelectorAll("tbody tr");
-    expect(paidRows.length).toBe(1);
+    expect(paidRows.length).toBe(2);
     expect(paidRows[0].children[0].textContent).toBe("T1");
     expect(paidRows[0].children[1].classList.contains("person-highlight")).toBe(
       true,
     );
+    expect(paidRows[1].classList.contains("total-row")).toBe(true);
+    expect(paidRows[1].children[2].textContent).toBe("$10.00");
 
     const sharedRows = tables[1].querySelectorAll("tbody tr");
-    expect(sharedRows.length).toBe(2);
+    expect(sharedRows.length).toBe(3);
     expect(sharedRows[0].children[2].textContent).toBe("$5.00");
     expect(sharedRows[1].children[2].textContent).toBe("$10.00");
     expect(
@@ -48,9 +50,11 @@ describe("person view helpers", () => {
     expect(
       sharedRows[1].children[2].classList.contains("person-highlight"),
     ).toBe(true);
+    expect(sharedRows[2].classList.contains("total-row")).toBe(true);
+    expect(sharedRows[2].children[2].textContent).toBe("$15.00");
 
     const settlementRows = tables[2].querySelectorAll("tbody tr");
-    expect(settlementRows.length).toBe(1);
+    expect(settlementRows.length).toBe(2);
     expect(settlementRows[0].children[0].textContent).toBe("A");
     expect(settlementRows[0].children[1].textContent).toBe("B");
     expect(
@@ -60,6 +64,8 @@ describe("person view helpers", () => {
       settlementRows[0].children[1].classList.contains("settlement-person"),
     ).toBe(false);
     expect(settlementRows[0].children[2].textContent).toBe("$5.00");
+    expect(settlementRows[1].classList.contains("total-row")).toBe(true);
+    expect(settlementRows[1].children[2].textContent).toBe("$5.00");
   });
 
   test("renderPersonView handles missing transactions and splits", () => {
@@ -90,9 +96,11 @@ describe("person view helpers", () => {
     ).toBe(true);
 
     const txRows = document.querySelectorAll("#transaction-table tbody tr");
+    expect(txRows.length).toBe(4);
     expect(txRows[0].classList.contains("person-highlight")).toBe(true);
-    expect(txRows[1].classList.contains("person-highlight")).toBe(true);
+    expect(txRows[1].classList.contains("person-highlight")).toBe(false);
     expect(txRows[2].classList.contains("person-highlight")).toBe(false);
+    expect(txRows[3].classList.contains("person-highlight")).toBe(false);
 
     const splitRows = document.querySelectorAll("#split-table tbody tr");
     expect(

--- a/tests/personView.test.js
+++ b/tests/personView.test.js
@@ -1,10 +1,14 @@
 /**
  * @jest-environment jsdom
  */
-import { renderPersonView } from "../src/render.js";
+import {
+  renderPersonView,
+  showPersonSummary,
+  calculateSummary,
+} from "../src/render.js";
 import { resetState, people, transactions } from "../src/state.js";
 
-describe("renderPersonView", () => {
+describe("person view helpers", () => {
   beforeEach(() => {
     resetState();
     people.push("A", "B");
@@ -14,7 +18,7 @@ describe("renderPersonView", () => {
     );
   });
 
-  test("builds sections for paid, shared and settlement", () => {
+  test("renderPersonView builds sections for paid, shared and settlement", () => {
     const view = renderPersonView(0);
     const tables = view.querySelectorAll("table");
     expect(tables.length).toBe(3);
@@ -39,5 +43,21 @@ describe("renderPersonView", () => {
       settlementRows[0].children[1].classList.contains("settlement-person"),
     ).toBe(false);
     expect(settlementRows[0].children[2].textContent).toBe("$5.00");
+  });
+
+  test("showPersonSummary appends view below summary and closes", () => {
+    document.body.innerHTML = '<div id="summary"></div>';
+    calculateSummary();
+    showPersonSummary(0);
+
+    const summaryTable = document.querySelector("#summary > table");
+    expect(summaryTable).not.toBeNull();
+
+    const personDiv = document.getElementById("person-summary");
+    expect(personDiv).not.toBeNull();
+    expect(personDiv.querySelectorAll("table").length).toBe(3);
+
+    personDiv.querySelector("button")?.click();
+    expect(document.getElementById("person-summary")).toBeNull();
   });
 });

--- a/tests/personView.test.js
+++ b/tests/personView.test.js
@@ -25,11 +25,19 @@ describe("renderPersonView", () => {
 
     const sharedRows = tables[1].querySelectorAll("tbody tr");
     expect(sharedRows.length).toBe(2);
+    expect(sharedRows[0].children[2].textContent).toBe("$5.00");
+    expect(sharedRows[1].children[2].textContent).toBe("$10.00");
 
     const settlementRows = tables[2].querySelectorAll("tbody tr");
     expect(settlementRows.length).toBe(1);
     expect(settlementRows[0].children[0].textContent).toBe("A");
     expect(settlementRows[0].children[1].textContent).toBe("B");
+    expect(
+      settlementRows[0].children[0].classList.contains("settlement-person"),
+    ).toBe(true);
+    expect(
+      settlementRows[0].children[1].classList.contains("settlement-person"),
+    ).toBe(false);
     expect(settlementRows[0].children[2].textContent).toBe("$5.00");
   });
 });

--- a/tests/personView.test.js
+++ b/tests/personView.test.js
@@ -5,6 +5,8 @@ import {
   renderPersonView,
   showPersonSummary,
   calculateSummary,
+  renderTransactionTable,
+  renderSplitTable,
 } from "../src/render.js";
 import { resetState, people, transactions } from "../src/state.js";
 
@@ -70,29 +72,65 @@ describe("person view helpers", () => {
     expect(view.textContent).toContain("A has no settlements.");
   });
 
-  test("showPersonSummary appends view below summary and closes", () => {
-    document.body.innerHTML = '<div id="summary"></div>';
+  test("showPersonSummary highlights related sections and closes", () => {
+    transactions.push({ name: "T3", payer: 1, cost: 5, splits: [0, 1] });
+    document.body.innerHTML =
+      '<div id="summary"></div><div id="transaction-table"></div><div id="split-table"></div><div id="split-details"></div>';
+    renderTransactionTable();
+    renderSplitTable();
     calculateSummary();
     showPersonSummary(0);
 
     const summaryTable = document.querySelector("#summary > table");
     expect(summaryTable).not.toBeNull();
+    expect(
+      summaryTable
+        ?.querySelectorAll("tbody tr")[0]
+        .classList.contains("person-highlight"),
+    ).toBe(true);
 
-    const highlighted = summaryTable
-      ?.querySelectorAll("tbody tr")[0]
-      .classList.contains("person-highlight");
-    expect(highlighted).toBe(true);
+    const txRows = document.querySelectorAll("#transaction-table tbody tr");
+    expect(txRows[0].classList.contains("person-highlight")).toBe(true);
+    expect(txRows[1].classList.contains("person-highlight")).toBe(true);
+    expect(txRows[2].classList.contains("person-highlight")).toBe(false);
 
-    const personDiv = document.getElementById("person-summary");
-    expect(personDiv).not.toBeNull();
-    expect(personDiv.querySelector("h3")?.textContent).toBe("A summary");
-    expect(personDiv.querySelectorAll("table").length).toBe(3);
+    const splitRows = document.querySelectorAll("#split-table tbody tr");
+    expect(
+      splitRows[0].children[2].classList.contains("person-highlight"),
+    ).toBe(true);
+    expect(
+      splitRows[1].children[2].classList.contains("person-highlight"),
+    ).toBe(true);
+    expect(
+      splitRows[2].children[2].classList.contains("person-highlight"),
+    ).toBe(false);
 
-    personDiv.querySelector("button")?.click();
+    const detailRows = document.querySelectorAll("#split-details tbody tr");
+    expect(
+      detailRows[0].children[1].classList.contains("person-highlight"),
+    ).toBe(true);
+    expect(
+      detailRows[1].children[1].classList.contains("person-highlight"),
+    ).toBe(true);
+    expect(
+      detailRows[2].children[1].classList.contains("person-highlight"),
+    ).toBe(false);
+    const totalRow = detailRows[detailRows.length - 1];
+    expect(totalRow.children[1].classList.contains("person-highlight")).toBe(
+      true,
+    );
+
+    expect(document.getElementById("person-summary-separator")).not.toBeNull();
+
+    document.querySelector("#person-summary button")?.click();
     expect(document.getElementById("person-summary")).toBeNull();
-    const cleared = summaryTable
-      ?.querySelectorAll("tbody tr")[0]
-      .classList.contains("person-highlight");
-    expect(cleared).toBe(false);
+    expect(document.getElementById("person-summary-separator")).toBeNull();
+    expect(txRows[0].classList.contains("person-highlight")).toBe(false);
+    expect(
+      splitRows[0].children[2].classList.contains("person-highlight"),
+    ).toBe(false);
+    expect(
+      detailRows[0].children[1].classList.contains("person-highlight"),
+    ).toBe(false);
   });
 });

--- a/tests/stateHelpers.test.js
+++ b/tests/stateHelpers.test.js
@@ -8,6 +8,7 @@ import {
   getTransactionsPaidBy,
   getTransactionsInvolving,
   getSettlementsFor,
+  getShareForTransaction,
 } from "../src/state.js";
 
 describe("state helper filters", () => {
@@ -51,5 +52,22 @@ describe("state helper filters", () => {
   test("getSettlementsFor filters settlement list", () => {
     transactions.push({ payer: 0, cost: 30, splits: [1, 1, 0] });
     expect(getSettlementsFor(1)).toEqual([{ from: 1, to: 0, amount: 15 }]);
+  });
+
+  test("getShareForTransaction handles simple and itemized splits", () => {
+    const simple = { payer: 0, cost: 30, splits: [1, 1, 2] };
+    expect(getShareForTransaction(simple, 1)).toBeCloseTo(7.5);
+
+    const itemized = {
+      payer: 0,
+      cost: 10,
+      splits: [1, 1],
+      items: [
+        { cost: 2, splits: [1, 0] },
+        { cost: 3, splits: [0, 1] },
+        { cost: 5, splits: [1, 1] },
+      ],
+    };
+    expect(getShareForTransaction(itemized, 1)).toBeCloseTo(5.5);
   });
 });


### PR DESCRIPTION
## Summary
- allow clicking a name in the summary to show that person's transactions and settlements
- add a Back to Summary control to restore the global view

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8a57987d0832094d2fa059a2eed44