### PR TITLE
Skip summary table when no participants

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -954,10 +954,17 @@ function renderSplitDetails() {
 // ---- SUMMARY ----
 /**
  * Render a summary table of totals paid, owed and net for each person.
+ * Clears the summary area when there are no participants.
+ *
+ * @returns {void}
  */
 function calculateSummary() {
   const summaryEl = document.getElementById("summary");
   if (!summaryEl) return;
+  if (people.length === 0) {
+    summaryEl.innerHTML = "";
+    return;
+  }
   const { paid, owes, nets } = computeSummary(people, transactions);
   const settlements = computeSettlements(people, transactions);
   const maxAbs = Math.max(...nets.map((n) => Math.abs(n)), 1);

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -118,6 +118,11 @@ describe("calculateSummary settlements", () => {
     resetState();
   });
 
+  test("skips rendering summary table when there are no people", () => {
+    calculateSummary();
+    expect(document.querySelector("#summary table")).toBeNull();
+  });
+
   test("renders settlement suggestions", () => {
     people.push("Alice", "Bob");
     transactions.push({ payer: 0, cost: 30, splits: [1, 1] });


### PR DESCRIPTION
## Summary
- avoid rendering an empty summary table when there are no participants
- add a unit test covering the empty-summary scenario

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a969d8cd488320be358d27c5ec138d