### PR TITLE
feat: add receipt-based transaction creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ groups. Try the live demo at
 1. In the **People** section, add the names of all participants.
 2. In the **Transactions** section, add transactions with a name, payee, and
    cost. Use **Create transaction from receipt** to extract details from an
-   image (experimental).
+   image and edit the proposed transaction in a modal (experimental).
 3. In the **Cost Splits** section, choose how each expense is divided:
    - **Even** – split equally among participants.
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAIgJYB2J2ATiADTjYRbbwDaIAgtEQMZO0BCEAEY0QAYVQUYIALq0ALhVQkAzqi5yiEFS1AkMTBMTKURXCMrnwA7AA4AdABYAzLTCoAnibgAGWsqxEcsosAIzUYSHSAL7RQA)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ groups. Try the live demo at
 - Table rows tinted to match section bubbles for a cohesive appearance
 - Tables outlined with subtle borders and rounded corners for a softer look
 - Itemized and non-itemized transactions with proportional tax and tip
+- Create transactions from receipt images (experimental)
 - Shareable URLs and optional named session pools stored locally
 - Up and down arrows to reorder saved pools
 - Warns before discarding unsaved changes when switching pools
@@ -33,7 +34,8 @@ groups. Try the live demo at
 
 1. In the **People** section, add the names of all participants.
 2. In the **Transactions** section, add transactions with a name, payee, and
-   cost.
+   cost. Use **Create transaction from receipt** to extract details from an
+   image (experimental).
 3. In the **Cost Splits** section, choose how each expense is divided:
    - **Even** – split equally among participants.
      [Example](https://cost-splits.github.io/?state=N4IgDg9hA2IFwgKIA8CGBbM0CmcAEAIgJYB2J2ATiADTjYRbbwDaIAgtEQMZO0BCEAEY0QAYVQUYIALq0ALhVQkAzqi5yiEFS1AkMTBMTKURXCMrnwA7AA4AdABYAzLTCoAnibgAGWsqxEcsosAIzUYSHSAL7RQA)

--- a/index.html
+++ b/index.html
@@ -204,7 +204,9 @@
       aria-modal="true"
     >
       <div class="modal-content">
-        <img id="receipt-preview" alt="Receipt preview" />
+        <div id="receipt-preview-container">
+          <img id="receipt-preview" alt="Receipt preview" />
+        </div>
         <div id="receipt-proposed"></div>
         <div class="flex-row">
           <button id="receipt-add" type="button">Add Transaction</button>

--- a/index.html
+++ b/index.html
@@ -55,6 +55,20 @@
       <section id="transactions-section" class="section-block">
         <h2>2. Add Transactions</h2>
         <div id="transaction-table" class="table-container"></div>
+        <div class="flex-row">
+          <button id="receipt-upload" type="button">
+            Create transaction from receipt
+          </button>
+          <button id="receipt-debug" type="button">
+            Debug: sample receipt
+          </button>
+          <input
+            id="receipt-file"
+            type="file"
+            accept="image/*"
+            class="hidden"
+          />
+        </div>
       </section>
 
       <section id="splits-section" class="section-block">
@@ -182,6 +196,22 @@
         </a>
       </p>
     </footer>
+
+    <div
+      id="receipt-modal"
+      class="modal hidden"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div class="modal-content">
+        <img id="receipt-preview" alt="Receipt preview" />
+        <div id="receipt-proposed"></div>
+        <div class="flex-row">
+          <button id="receipt-add" type="button">Add Transaction</button>
+          <button id="receipt-cancel" type="button">Cancel</button>
+        </div>
+      </div>
+    </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.5.0/lz-string.min.js"></script>
     <script type="module" src="src/main.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,7 @@ import {
   updatePoolSaveStatus,
 } from "./share.js";
 import { initTabs } from "./tabs.js";
+import { initReceiptUpload } from "./receipt.js";
 
 setAfterChange(() => {
   updateCurrentStateJson();
@@ -77,6 +78,8 @@ document.getElementById("save-local").addEventListener("click", () => {
   savePoolToLocalStorage(pool, { people, transactions });
   renderSavedPoolsTable();
 });
+
+initReceiptUpload();
 
 document.getElementById("new-pool").addEventListener("click", () => {
   if (hasUnsavedChanges() && !confirm("You have unsaved changes. Continue?")) {

--- a/src/receipt.js
+++ b/src/receipt.js
@@ -1,5 +1,18 @@
-import { transactions, people, afterChange } from "./state.js";
-import { renderTransactionTable, renderSplitTable } from "./render.js";
+import {
+  transactions,
+  people,
+  afterChange,
+  isValidDollar,
+  isValidNumber,
+} from "./state.js";
+import {
+  renderTransactionTable,
+  renderSplitTable,
+  showError,
+  clearError,
+  COST_FORMAT_MSG,
+  NUMBER_FORMAT_MSG,
+} from "./render.js";
 
 let currentImageUrl = "";
 
@@ -96,7 +109,9 @@ export function initReceiptUpload() {
   /**
    * Collect transaction data from the modal inputs.
    *
-   * @returns {object} Transaction object assembled from user edits.
+   * Validates all numeric fields and returns null if any are invalid.
+   *
+   * @returns {object|null} Transaction object assembled from user edits or null if invalid.
    */
   function collectTransactionFromModal() {
     const name = document.getElementById("receipt-t-name").value.trim();
@@ -104,26 +119,54 @@ export function initReceiptUpload() {
       document.getElementById("receipt-t-payer").value,
       10,
     );
-    const cost =
-      parseFloat(document.getElementById("receipt-t-cost").value) || 0;
+    const costInput = document.getElementById("receipt-t-cost");
+    const costVal = costInput.value.trim();
+    let invalid = false;
+    if (!isValidDollar(costVal)) {
+      showError(costInput, COST_FORMAT_MSG);
+      invalid = true;
+    } else {
+      clearError(costInput);
+    }
     const items = [];
     const table = document.getElementById("receipt-items-table");
     if (table) {
       const rows = table.querySelectorAll("tbody tr");
       rows.forEach((row, ii) => {
-        const item = row.querySelector(`#receipt-item-${ii}-name`).value.trim();
-        const itemCost =
-          parseFloat(row.querySelector(`#receipt-item-${ii}-cost`).value) || 0;
+        const itemNameEl = row.querySelector(`#receipt-item-${ii}-name`);
+        const itemCostEl = row.querySelector(`#receipt-item-${ii}-cost`);
+        const itemCostVal = itemCostEl.value.trim();
+        if (!isValidDollar(itemCostVal)) {
+          showError(itemCostEl, COST_FORMAT_MSG);
+          invalid = true;
+        } else {
+          clearError(itemCostEl);
+        }
         const splits = people.map((_, pi) => {
-          const val = row.querySelector(
-            `#receipt-item-${ii}-split-${pi}`,
-          ).value;
-          return val ? parseFloat(val) : 0;
+          const splitEl = row.querySelector(`#receipt-item-${ii}-split-${pi}`);
+          const splitVal = splitEl.value.trim();
+          if (!isValidNumber(splitVal, true)) {
+            showError(splitEl, NUMBER_FORMAT_MSG);
+            invalid = true;
+          } else {
+            clearError(splitEl);
+          }
+          return splitVal ? parseFloat(splitVal) : 0;
         });
-        items.push({ item, cost: itemCost, splits });
+        items.push({
+          item: itemNameEl.value.trim(),
+          cost: parseFloat(itemCostVal) || 0,
+          splits,
+        });
       });
     }
-    const tx = { name, payer, cost, splits: people.map(() => 0) };
+    if (invalid) return null;
+    const tx = {
+      name,
+      payer,
+      cost: parseFloat(costVal) || 0,
+      splits: people.map(() => 0),
+    };
     if (items.length > 0) tx.items = items;
     return tx;
   }
@@ -178,7 +221,7 @@ function renderProposedTransaction(tx) {
 
   const costVal = typeof tx.cost === "number" ? tx.cost.toFixed(2) : "0";
   const costRow = document.createElement("tr");
-  costRow.innerHTML = `<th>Total Cost</th><td><input id="receipt-t-cost" type="number" step="0.01" value="${costVal}" /></td>`;
+  costRow.innerHTML = `<th>Total Cost</th><td><div class="dollar-field"><span class="prefix">$</span><input id="receipt-t-cost" type="text" value="${costVal}" /></div></td>`;
   txBody.appendChild(costRow);
 
   txTable.appendChild(txBody);
@@ -204,12 +247,10 @@ function renderProposedTransaction(tx) {
     let cells = `<td><input id="receipt-item-${ii}-name" type="text" value="${
       it.item || ""
     }" /></td>`;
-    cells += `<td><input id="receipt-item-${ii}-cost" type="number" step="0.01" value="${it.cost.toFixed(
-      2,
-    )}" /></td>`;
+    cells += `<td><div class="dollar-field"><span class="prefix">$</span><input id="receipt-item-${ii}-cost" type="text" value="${it.cost.toFixed(2)}" /></div></td>`;
     people.forEach((_, pi) => {
       const val = it.splits?.[pi] ?? 0;
-      cells += `<td><input id="receipt-item-${ii}-split-${pi}" type="number" min="0" value="${val}" /></td>`;
+      cells += `<td><input id="receipt-item-${ii}-split-${pi}" type="text" value="${val}" /></td>`;
     });
     const row = document.createElement("tr");
     row.innerHTML = cells;

--- a/src/receipt.js
+++ b/src/receipt.js
@@ -12,6 +12,7 @@ import {
   clearError,
   COST_FORMAT_MSG,
   NUMBER_FORMAT_MSG,
+  SPLIT_SUM_MSG,
 } from "./render.js";
 
 let currentImageUrl = "";
@@ -47,15 +48,15 @@ export function initReceiptUpload() {
   });
 
   debugBtn.addEventListener("click", () => {
-    const baseSplits = people.map(() => 1);
+    const emptySplits = people.map(() => 0);
     const tx = {
       name: "Sample Store",
       payer: 0,
       cost: 12.34,
-      splits: baseSplits.slice(),
+      splits: emptySplits.slice(),
       items: [
-        { item: "Coffee", cost: 4, splits: baseSplits.slice() },
-        { item: "Bagel", cost: 8.34, splits: baseSplits.slice() },
+        { item: "Coffee", cost: 4, splits: emptySplits.slice() },
+        { item: "Bagel", cost: 8.34, splits: emptySplits.slice() },
       ],
     };
     showModal("assets/icon-banner.png", tx);
@@ -153,6 +154,12 @@ export function initReceiptUpload() {
           }
           return splitVal ? parseFloat(splitVal) : 0;
         });
+        const splitTotal = splits.reduce((a, b) => a + b, 0);
+        if (splitTotal <= 0) {
+          const firstSplit = row.querySelector(`#receipt-item-${ii}-split-0`);
+          showError(firstSplit, SPLIT_SUM_MSG);
+          invalid = true;
+        }
         items.push({
           item: itemNameEl.value.trim(),
           cost: parseFloat(itemCostVal) || 0,
@@ -250,7 +257,8 @@ function renderProposedTransaction(tx) {
     cells += `<td><div class="dollar-field"><span class="prefix">$</span><input id="receipt-item-${ii}-cost" type="text" value="${it.cost.toFixed(2)}" /></div></td>`;
     people.forEach((_, pi) => {
       const val = it.splits?.[pi] ?? 0;
-      cells += `<td><input id="receipt-item-${ii}-split-${pi}" type="text" value="${val}" /></td>`;
+      const display = val > 0 ? val : "";
+      cells += `<td><input id="receipt-item-${ii}-split-${pi}" type="text" value="${display}" /></td>`;
     });
     const row = document.createElement("tr");
     row.innerHTML = cells;

--- a/src/receipt.js
+++ b/src/receipt.js
@@ -1,0 +1,137 @@
+import { transactions, people, afterChange } from "./state.js";
+import { renderTransactionTable, renderSplitTable } from "./render.js";
+
+let currentTransaction = null;
+let currentImageUrl = "";
+
+/**
+ * Initialize receipt upload and debug buttons.
+ *
+ * Sets up handlers for uploading a receipt image, extracting a transaction,
+ * and displaying a modal preview. Includes a debug button that injects a
+ * sample image and transaction.
+ *
+ * @returns {void}
+ */
+export function initReceiptUpload() {
+  const uploadBtn = document.getElementById("receipt-upload");
+  const debugBtn = document.getElementById("receipt-debug");
+  const fileInput = document.getElementById("receipt-file");
+  const modal = document.getElementById("receipt-modal");
+  const preview = document.getElementById("receipt-preview");
+  const proposed = document.getElementById("receipt-proposed");
+  const addBtn = document.getElementById("receipt-add");
+  const cancelBtn = document.getElementById("receipt-cancel");
+
+  uploadBtn.addEventListener("click", () => fileInput.click());
+
+  fileInput.addEventListener("change", async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    const tx = await extractTransactionFromImage(file);
+    showModal(url, tx);
+    fileInput.value = "";
+  });
+
+  debugBtn.addEventListener("click", () => {
+    const tx = {
+      name: "Sample Store",
+      payer: 0,
+      cost: 12.34,
+      splits: [1],
+      items: [
+        { item: "Coffee", cost: 4, splits: [1] },
+        { item: "Bagel", cost: 8.34, splits: [1] },
+      ],
+    };
+    showModal("assets/icon-banner.png", tx);
+  });
+
+  addBtn.addEventListener("click", () => {
+    if (!currentTransaction) return;
+    transactions.push(currentTransaction);
+    renderTransactionTable();
+    renderSplitTable();
+    afterChange();
+    hideModal();
+  });
+
+  cancelBtn.addEventListener("click", hideModal);
+
+  /**
+   * Display the modal with the provided image and transaction.
+   *
+   * @param {string} imgUrl - Image URL for preview.
+   * @param {object} tx - Transaction data to display.
+   * @returns {void}
+   */
+  function showModal(imgUrl, tx) {
+    currentTransaction = tx;
+    currentImageUrl = imgUrl;
+    preview.src = imgUrl;
+    proposed.innerHTML = "";
+    proposed.appendChild(renderProposedTransaction(tx));
+    modal.classList.remove("hidden");
+  }
+
+  /**
+   * Hide the receipt modal and clean up resources.
+   *
+   * @returns {void}
+   */
+  function hideModal() {
+    modal.classList.add("hidden");
+    preview.src = "";
+    proposed.innerHTML = "";
+    if (currentImageUrl.startsWith("blob:")) {
+      URL.revokeObjectURL(currentImageUrl);
+    }
+    currentImageUrl = "";
+    currentTransaction = null;
+  }
+}
+
+/**
+ * Stub for extracting transaction data from a receipt image.
+ *
+ * This placeholder simply returns an empty transaction structure. Future
+ * implementations can replace this with real receipt parsing logic.
+ *
+ * @param {File} _file - Image file to parse.
+ * @returns {Promise<object>} Proposed transaction data.
+ */
+export async function extractTransactionFromImage(_file) {
+  return {
+    name: "Receipt",
+    payer: 0,
+    cost: 0,
+    splits: people.map(() => 1),
+  };
+}
+
+/**
+ * Build a simple view of the proposed transaction and items.
+ *
+ * @param {object} tx - Transaction to render.
+ * @returns {HTMLElement} Container with transaction details.
+ */
+function renderProposedTransaction(tx) {
+  const container = document.createElement("div");
+  const name = document.createElement("p");
+  name.textContent = `Name: ${tx.name}`;
+  const cost = document.createElement("p");
+  cost.textContent = `Cost: ${tx.cost}`;
+  container.appendChild(name);
+  container.appendChild(cost);
+  if (Array.isArray(tx.items) && tx.items.length > 0) {
+    const list = document.createElement("ul");
+    tx.items.forEach((it) => {
+      const li = document.createElement("li");
+      li.textContent = `${it.item ?? "Item"} - ${it.cost}`;
+      list.appendChild(li);
+    });
+    container.appendChild(list);
+  }
+  return container;
+}

--- a/src/receipt.js
+++ b/src/receipt.js
@@ -221,32 +221,46 @@ export async function extractTransactionFromImage(_file) {
 function renderProposedTransaction(tx) {
   const container = document.createElement("div");
 
-  const txTable = document.createElement("table");
-  const txBody = document.createElement("tbody");
+  const nameRow = document.createElement("div");
+  nameRow.className = "flex-row";
+  const nameLabel = document.createElement("label");
+  nameLabel.htmlFor = "receipt-t-name";
+  nameLabel.textContent = "Transaction";
+  const nameInput = document.createElement("input");
+  nameInput.id = "receipt-t-name";
+  nameInput.type = "text";
+  nameInput.value = tx.name || "";
+  nameRow.append(nameLabel, nameInput);
+  container.appendChild(nameRow);
 
-  const nameRow = document.createElement("tr");
-  nameRow.innerHTML = `<th>Transaction</th><td><input id="receipt-t-name" type="text" value="${
-    tx.name || ""
-  }" /></td>`;
-  txBody.appendChild(nameRow);
-
-  let payerCell = '<th>Payer</th><td><select id="receipt-t-payer">';
+  const payerRow = document.createElement("div");
+  payerRow.className = "flex-row";
+  const payerLabel = document.createElement("label");
+  payerLabel.htmlFor = "receipt-t-payer";
+  payerLabel.textContent = "Payer";
+  const payerSelect = document.createElement("select");
+  payerSelect.id = "receipt-t-payer";
   people.forEach((p, i) => {
-    const sel = i === (tx.payer || 0) ? " selected" : "";
-    payerCell += `<option value="${i}"${sel}>${p}</option>`;
+    const opt = document.createElement("option");
+    opt.value = i;
+    opt.textContent = p;
+    if (i === (tx.payer || 0)) opt.selected = true;
+    payerSelect.appendChild(opt);
   });
-  payerCell += "</select></td>";
-  const payerRow = document.createElement("tr");
-  payerRow.innerHTML = payerCell;
-  txBody.appendChild(payerRow);
+  payerRow.append(payerLabel, payerSelect);
+  container.appendChild(payerRow);
 
+  const costRow = document.createElement("div");
+  costRow.className = "flex-row";
+  const costLabel = document.createElement("label");
+  costLabel.htmlFor = "receipt-t-cost";
+  costLabel.textContent = "Total Cost";
   const costVal = typeof tx.cost === "number" ? tx.cost.toFixed(2) : "0";
-  const costRow = document.createElement("tr");
-  costRow.innerHTML = `<th>Total Cost</th><td><div class="dollar-field"><span class="prefix">$</span><input id="receipt-t-cost" type="text" value="${costVal}" /></div></td>`;
-  txBody.appendChild(costRow);
-
-  txTable.appendChild(txBody);
-  container.appendChild(txTable);
+  const costField = document.createElement("div");
+  costField.className = "dollar-field";
+  costField.innerHTML = `<span class="prefix">$</span><input id="receipt-t-cost" type="text" value="${costVal}" />`;
+  costRow.append(costLabel, costField);
+  container.appendChild(costRow);
 
   const items =
     Array.isArray(tx.items) && tx.items.length > 0
@@ -265,9 +279,7 @@ function renderProposedTransaction(tx) {
 
   const tbody = document.createElement("tbody");
   items.forEach((it, ii) => {
-    let cells = `<td><input id="receipt-item-${ii}-name" type="text" value="${
-      it.item || ""
-    }" /></td>`;
+    let cells = `<td><input id="receipt-item-${ii}-name" type="text" value="${it.item || ""}" /></td>`;
     cells += `<td><div class="dollar-field"><span class="prefix">$</span><input id="receipt-item-${ii}-cost" type="text" value="${it.cost.toFixed(2)}" /></div></td>`;
     people.forEach((_, pi) => {
       const val = it.splits?.[pi] ?? 0;

--- a/src/receipt.js
+++ b/src/receipt.js
@@ -80,6 +80,8 @@ export function initReceiptUpload() {
   /**
    * Display the modal with the provided image and transaction.
    *
+   * Locks background scrolling while the modal is active.
+   *
    * @param {string} imgUrl - Image URL for preview.
    * @param {object} tx - Transaction data to display.
    * @returns {void}
@@ -89,16 +91,20 @@ export function initReceiptUpload() {
     preview.src = imgUrl;
     proposed.innerHTML = "";
     proposed.appendChild(renderProposedTransaction(tx));
+    document.body.classList.add("modal-open");
     modal.classList.remove("hidden");
   }
 
   /**
    * Hide the receipt modal and clean up resources.
    *
+   * Re-enables background scrolling once closed.
+   *
    * @returns {void}
    */
   function hideModal() {
     modal.classList.add("hidden");
+    document.body.classList.remove("modal-open");
     preview.src = "";
     proposed.innerHTML = "";
     if (currentImageUrl.startsWith("blob:")) {

--- a/src/receipt.js
+++ b/src/receipt.js
@@ -143,8 +143,10 @@ export function initReceiptUpload() {
         } else {
           clearError(itemCostEl);
         }
-        const splits = people.map((_, pi) => {
-          const splitEl = row.querySelector(`#receipt-item-${ii}-split-${pi}`);
+        const splitEls = people.map((_, pi) =>
+          row.querySelector(`#receipt-item-${ii}-split-${pi}`),
+        );
+        const splits = splitEls.map((splitEl) => {
           const splitVal = splitEl.value.trim();
           if (!isValidNumber(splitVal, true)) {
             showError(splitEl, NUMBER_FORMAT_MSG);
@@ -156,8 +158,20 @@ export function initReceiptUpload() {
         });
         const splitTotal = splits.reduce((a, b) => a + b, 0);
         if (splitTotal <= 0) {
-          const firstSplit = row.querySelector(`#receipt-item-${ii}-split-0`);
-          showError(firstSplit, SPLIT_SUM_MSG);
+          splitEls.forEach((el, idx) => {
+            if (idx === splitEls.length - 1) {
+              showError(el, SPLIT_SUM_MSG);
+            } else {
+              el.classList.add("invalid-cell");
+              el.addEventListener(
+                "input",
+                () => {
+                  clearError(el);
+                },
+                { once: true },
+              );
+            }
+          });
           invalid = true;
         }
         items.push({

--- a/src/receipt.js
+++ b/src/receipt.js
@@ -1,7 +1,6 @@
 import { transactions, people, afterChange } from "./state.js";
 import { renderTransactionTable, renderSplitTable } from "./render.js";
 
-let currentTransaction = null;
 let currentImageUrl = "";
 
 /**
@@ -35,22 +34,24 @@ export function initReceiptUpload() {
   });
 
   debugBtn.addEventListener("click", () => {
+    const baseSplits = people.map(() => 1);
     const tx = {
       name: "Sample Store",
       payer: 0,
       cost: 12.34,
-      splits: [1],
+      splits: baseSplits.slice(),
       items: [
-        { item: "Coffee", cost: 4, splits: [1] },
-        { item: "Bagel", cost: 8.34, splits: [1] },
+        { item: "Coffee", cost: 4, splits: baseSplits.slice() },
+        { item: "Bagel", cost: 8.34, splits: baseSplits.slice() },
       ],
     };
     showModal("assets/icon-banner.png", tx);
   });
 
   addBtn.addEventListener("click", () => {
-    if (!currentTransaction) return;
-    transactions.push(currentTransaction);
+    const tx = collectTransactionFromModal();
+    if (!tx) return;
+    transactions.push(tx);
     renderTransactionTable();
     renderSplitTable();
     afterChange();
@@ -70,7 +71,6 @@ export function initReceiptUpload() {
    * @returns {void}
    */
   function showModal(imgUrl, tx) {
-    currentTransaction = tx;
     currentImageUrl = imgUrl;
     preview.src = imgUrl;
     proposed.innerHTML = "";
@@ -91,7 +91,41 @@ export function initReceiptUpload() {
       URL.revokeObjectURL(currentImageUrl);
     }
     currentImageUrl = "";
-    currentTransaction = null;
+  }
+
+  /**
+   * Collect transaction data from the modal inputs.
+   *
+   * @returns {object} Transaction object assembled from user edits.
+   */
+  function collectTransactionFromModal() {
+    const name = document.getElementById("receipt-t-name").value.trim();
+    const payer = parseInt(
+      document.getElementById("receipt-t-payer").value,
+      10,
+    );
+    const cost =
+      parseFloat(document.getElementById("receipt-t-cost").value) || 0;
+    const items = [];
+    const table = document.getElementById("receipt-items-table");
+    if (table) {
+      const rows = table.querySelectorAll("tbody tr");
+      rows.forEach((row, ii) => {
+        const item = row.querySelector(`#receipt-item-${ii}-name`).value.trim();
+        const itemCost =
+          parseFloat(row.querySelector(`#receipt-item-${ii}-cost`).value) || 0;
+        const splits = people.map((_, pi) => {
+          const val = row.querySelector(
+            `#receipt-item-${ii}-split-${pi}`,
+          ).value;
+          return val ? parseFloat(val) : 0;
+        });
+        items.push({ item, cost: itemCost, splits });
+      });
+    }
+    const tx = { name, payer, cost, splits: people.map(() => 0) };
+    if (items.length > 0) tx.items = items;
+    return tx;
   }
 }
 
@@ -109,32 +143,80 @@ export async function extractTransactionFromImage(_file) {
     name: "Receipt",
     payer: 0,
     cost: 0,
-    splits: people.map(() => 1),
+    splits: people.map(() => 0),
+    items: [{ item: "", cost: 0, splits: people.map(() => 0) }],
   };
 }
 
 /**
- * Build a simple view of the proposed transaction and items.
+ * Render an editable transaction proposal form.
  *
- * @param {object} tx - Transaction to render.
- * @returns {HTMLElement} Container with transaction details.
+ * @param {object} tx - Transaction data to prefill.
+ * @returns {HTMLElement} Container with form inputs.
  */
 function renderProposedTransaction(tx) {
   const container = document.createElement("div");
-  const name = document.createElement("p");
-  name.textContent = `Name: ${tx.name}`;
-  const cost = document.createElement("p");
-  cost.textContent = `Cost: ${tx.cost}`;
-  container.appendChild(name);
-  container.appendChild(cost);
-  if (Array.isArray(tx.items) && tx.items.length > 0) {
-    const list = document.createElement("ul");
-    tx.items.forEach((it) => {
-      const li = document.createElement("li");
-      li.textContent = `${it.item ?? "Item"} - ${it.cost}`;
-      list.appendChild(li);
+
+  const txTable = document.createElement("table");
+  const txBody = document.createElement("tbody");
+
+  const nameRow = document.createElement("tr");
+  nameRow.innerHTML = `<th>Transaction</th><td><input id="receipt-t-name" type="text" value="${
+    tx.name || ""
+  }" /></td>`;
+  txBody.appendChild(nameRow);
+
+  let payerCell = '<th>Payer</th><td><select id="receipt-t-payer">';
+  people.forEach((p, i) => {
+    const sel = i === (tx.payer || 0) ? " selected" : "";
+    payerCell += `<option value="${i}"${sel}>${p}</option>`;
+  });
+  payerCell += "</select></td>";
+  const payerRow = document.createElement("tr");
+  payerRow.innerHTML = payerCell;
+  txBody.appendChild(payerRow);
+
+  const costVal = typeof tx.cost === "number" ? tx.cost.toFixed(2) : "0";
+  const costRow = document.createElement("tr");
+  costRow.innerHTML = `<th>Total Cost</th><td><input id="receipt-t-cost" type="number" step="0.01" value="${costVal}" /></td>`;
+  txBody.appendChild(costRow);
+
+  txTable.appendChild(txBody);
+  container.appendChild(txTable);
+
+  const items =
+    Array.isArray(tx.items) && tx.items.length > 0
+      ? tx.items
+      : [{ item: "", cost: 0, splits: people.map(() => 0) }];
+  const table = document.createElement("table");
+  table.id = "receipt-items-table";
+  const thead = document.createElement("thead");
+  let header = "<tr><th>Item</th><th>Cost</th>";
+  people.forEach((p) => {
+    header += `<th>${p}</th>`;
+  });
+  header += "</tr>";
+  thead.innerHTML = header;
+  table.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+  items.forEach((it, ii) => {
+    let cells = `<td><input id="receipt-item-${ii}-name" type="text" value="${
+      it.item || ""
+    }" /></td>`;
+    cells += `<td><input id="receipt-item-${ii}-cost" type="number" step="0.01" value="${it.cost.toFixed(
+      2,
+    )}" /></td>`;
+    people.forEach((_, pi) => {
+      const val = it.splits?.[pi] ?? 0;
+      cells += `<td><input id="receipt-item-${ii}-split-${pi}" type="number" min="0" value="${val}" /></td>`;
     });
-    container.appendChild(list);
-  }
+    const row = document.createElement("tr");
+    row.innerHTML = cells;
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+  container.appendChild(table);
+
   return container;
 }

--- a/src/receipt.js
+++ b/src/receipt.js
@@ -57,7 +57,10 @@ export function initReceiptUpload() {
     hideModal();
   });
 
-  cancelBtn.addEventListener("click", hideModal);
+  cancelBtn.addEventListener("click", () => {
+    hideModal();
+    fileInput.value = "";
+  });
 
   /**
    * Display the modal with the provided image and transaction.

--- a/src/render.js
+++ b/src/render.js
@@ -27,6 +27,7 @@ const COST_FORMAT_MSG =
   "Cost must be digits with optional decimal point and up to two decimals (e.g., 12 or 3.50).";
 const NUMBER_FORMAT_MSG =
   "Number must be digits with optional decimals (e.g., 3 or 0.75).";
+const SPLIT_SUM_MSG = "Splits must sum to more than 0.";
 
 /**
  * Display an error indicator next to an invalid field.
@@ -1387,4 +1388,5 @@ export {
   clearError,
   COST_FORMAT_MSG,
   NUMBER_FORMAT_MSG,
+  SPLIT_SUM_MSG,
 };

--- a/src/render.js
+++ b/src/render.js
@@ -1383,4 +1383,8 @@ export {
   renderSavedPoolsTable,
   renderPersonView,
   showPersonSummary,
+  showError,
+  clearError,
+  COST_FORMAT_MSG,
+  NUMBER_FORMAT_MSG,
 };

--- a/styles.css
+++ b/styles.css
@@ -483,10 +483,17 @@ input[data-action="editItemSplit"] {
   border-radius: 0.5rem;
 }
 
-#receipt-preview {
+#receipt-preview-container {
   max-width: 100%;
-  height: auto;
+  max-height: 300px;
+  overflow-y: auto;
   margin-bottom: var(--spacing);
+}
+
+#receipt-preview {
+  width: 100%;
+  height: auto;
+  display: block;
 }
 
 footer {

--- a/styles.css
+++ b/styles.css
@@ -457,6 +457,34 @@ input[data-action="editItemSplit"] {
   overflow-x: auto;
 }
 
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #fff;
+  padding: var(--spacing);
+  max-width: 90%;
+  max-height: 90%;
+  overflow-y: auto;
+  border-radius: 0.5rem;
+}
+
+#receipt-preview {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: var(--spacing);
+}
+
 footer {
   margin-top: calc(var(--spacing) * 4);
   text-align: center;

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,10 @@ body {
   color: var(--text-color);
 }
 
+body.modal-open {
+  overflow: hidden;
+}
+
 h1 {
   color: var(--primary-color);
 }
@@ -485,15 +489,16 @@ input[data-action="editItemSplit"] {
 
 #receipt-preview-container {
   max-width: 100%;
-  max-height: 300px;
-  overflow-y: auto;
+  max-height: 500px;
+  overflow: auto;
   margin-bottom: var(--spacing);
 }
 
 #receipt-preview {
-  width: 100%;
-  height: auto;
+  max-height: 500px;
+  width: auto;
   display: block;
+  margin: 0 auto;
 }
 
 #receipt-proposed {

--- a/styles.css
+++ b/styles.css
@@ -496,6 +496,10 @@ input[data-action="editItemSplit"] {
   display: block;
 }
 
+#receipt-proposed {
+  padding-bottom: calc(var(--spacing) * 2);
+}
+
 footer {
   margin-top: calc(var(--spacing) * 4);
   text-align: center;

--- a/styles.css
+++ b/styles.css
@@ -470,6 +470,10 @@ input[data-action="editItemSplit"] {
   z-index: 1000;
 }
 
+.modal.hidden {
+  display: none;
+}
+
 .modal-content {
   background: #fff;
   padding: var(--spacing);


### PR DESCRIPTION
## Summary
- add button to create transactions from receipt images with modal preview
- include debug helper to inject sample image and itemized transaction
- document experimental receipt feature

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af9e581a408320919e84646cd30c87